### PR TITLE
Call addApi before addAction in AbstractPaymentFactory

### DIFF
--- a/DependencyInjection/Factory/Payment/AbstractPaymentFactory.php
+++ b/DependencyInjection/Factory/Payment/AbstractPaymentFactory.php
@@ -19,17 +19,17 @@ abstract class AbstractPaymentFactory implements PaymentFactoryInterface
         $paymentId = 'payum.context.'.$contextName.'.payment';
         $container->setDefinition($paymentId, $paymentDefinition);
 
-        foreach (array_reverse($config['actions']) as $actionId) {
-            $paymentDefinition->addMethodCall(
-                'addAction',
-                array(new Reference($actionId), $forcePrepend = true)
-            );
-        }
-
         foreach (array_reverse($config['apis']) as $apiId) {
             $paymentDefinition->addMethodCall(
                 'addApi',
                 array(new Reference($apiId), $forcePrepend = true)
+            );
+        }
+
+        foreach (array_reverse($config['actions']) as $actionId) {
+            $paymentDefinition->addMethodCall(
+                'addAction',
+                array(new Reference($actionId), $forcePrepend = true)
             );
         }
 


### PR DESCRIPTION
Custom payments loading any Actions implementing ApiAwareInterface will throw an Exception since addApi() isn't called until after addAction().

This PR simply flips addApi() and addAction() in the AbstractPaymentFactory so that the Apis are injected first.

The phpunit output was identical before and after this change.
