### PR TITLE
Allow JSON as request content.

### DIFF
--- a/Controller/NotifyController.php
+++ b/Controller/NotifyController.php
@@ -12,6 +12,12 @@ class NotifyController extends PayumController
     {
         $payment = $this->getPayum()->getPayment($request->get('payment_name'));
 
+        // Convert JSON content to POST request
+        if (0 === strpos($request->headers->get('Content-Type'), 'application/json')) {
+            $data = json_decode($request->getContent(), true);
+            $request->request->replace(is_array($data) ? $data : array());
+        }
+
         $payment->execute(new NotifyRequest(array_replace(
             $request->query->all(),
             $request->request->all()


### PR DESCRIPTION
The action wasn't able to handle JSON format data.
