### PR TITLE
Payum action tag

### DIFF
--- a/DependencyInjection/Compiler/PayumActionsPass.php
+++ b/DependencyInjection/Compiler/PayumActionsPass.php
@@ -1,0 +1,99 @@
+<?php
+namespace Payum\Bundle\PayumBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class PayumActionsPass implements CompilerPassInterface
+{
+
+    /**
+     * {@inheritDoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        foreach ($container->findTaggedServiceIds('payum.action') as $id => $tagAttributes) {
+
+            foreach ($tagAttributes as $attributes) {
+                $paymentIds = array();
+
+                if (isset($attributes['all']) && $attributes['all']) {
+                    $paymentIds = array_merge($paymentIds, $this->findAllPaymentIds($container));
+                }
+
+                if (isset($attributes['factory']) && $attributes['factory']) {
+                    $paymentIds = array_merge(
+                        $paymentIds,
+                        $this->findPaymentIdsByFactory($container, $attributes['factory'])
+                    );
+                }
+                if (isset($attributes['context']) && $attributes['context']) {
+                    $paymentIds = array_merge(
+                        $paymentIds,
+                        $this->findPaymentIdsByContext($container, $attributes['context'])
+                    );
+                }
+
+                $paymentIds = array_filter(array_unique($paymentIds));
+                foreach ($paymentIds as $paymentId) {
+                    $payment = $container->getDefinition($paymentId);
+                    $payment->addMethodCall('addAction', array(
+                        new Reference($id),
+                        isset($attributes['prepend']) && $attributes['prepend']
+                    ));
+                }
+            }
+        }
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     * @param string $factoryName
+     *
+     * @return string[]
+     */
+    protected function findPaymentIdsByFactory(ContainerBuilder $container, $factoryName)
+    {
+        $paymentIds = array();
+        foreach ($container->findTaggedServiceIds('payum.payment') as $id => $tagAttributes) {
+            foreach ($tagAttributes as $attributes) {
+                if (isset($attributes['factory']) && $attributes['factory'] == $factoryName) {
+                    $paymentIds[] = $id;
+                }
+            }
+        }
+
+        return $paymentIds;
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     * @param string $contextName
+     *
+     * @return string[]
+     */
+    protected function findPaymentIdsByContext(ContainerBuilder $container, $contextName)
+    {
+        $paymentIds = array();
+        foreach ($container->findTaggedServiceIds('payum.payment') as $id => $tagAttributes) {
+            foreach ($tagAttributes as $attributes) {
+                if (isset($attributes['context']) && $attributes['context'] == $contextName) {
+                    $paymentIds[] = $id;
+                }
+            }
+        }
+
+        return $paymentIds;
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     *
+     * @return string[]
+     */
+    protected function findAllPaymentIds(ContainerBuilder $container)
+    {
+        return array_keys($container->findTaggedServiceIds('payum.payment'));
+    }
+}

--- a/DependencyInjection/Factory/Payment/PaymentFactoryInterface.php
+++ b/DependencyInjection/Factory/Payment/PaymentFactoryInterface.php
@@ -1,13 +1,14 @@
 <?php
 namespace Payum\Bundle\PayumBundle\DependencyInjection\Factory\Payment;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 interface PaymentFactoryInterface
 {
     /**
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     * @param ContainerBuilder $container
      * @param string $contextName
      * @param array $config
      * 
@@ -24,7 +25,7 @@ interface PaymentFactoryInterface
     function getName();
 
     /**
-     * @param \Symfony\Component\Config\Definition\Builder\NodeDefinition $builder
+     * @param NodeDefinition $builder
      * 
      * @return void
      */

--- a/DependencyInjection/PayumExtension.php
+++ b/DependencyInjection/PayumExtension.php
@@ -69,7 +69,12 @@ class PayumExtension extends Extension
                 $contextConfig[$paymentFactoryName]
             );
             $paymentsServicesIds[$contextName] = $paymentId;
-            
+
+            $container->getDefinition($paymentId)->addTag('payum.payment', array(
+                'factory' => $paymentFactoryName,
+                'context' => $contextName
+            ));
+
             foreach ($contextConfig['storages'] as $modelClass => $storageConfig) {
                 $storageFactoryName = $this->findSelectedStorageFactoryNameInStorageConfig($storageConfig);
                 $storageId = $this->storageFactories[$storageFactoryName]->create(

--- a/PayumBundle.php
+++ b/PayumBundle.php
@@ -1,6 +1,7 @@
 <?php
 namespace Payum\Bundle\PayumBundle;
 
+use Payum\Bundle\PayumBundle\DependencyInjection\Compiler\PayumActionsPass;
 use Payum\Bundle\PayumBundle\DependencyInjection\Factory\Payment\KlarnaCheckoutPaymentFactory;
 use Payum\Bundle\PayumBundle\DependencyInjection\Factory\Payment\OfflinePaymentFactory;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -37,5 +38,7 @@ class PayumBundle extends Bundle
 
         $extension->addStorageFactory(new FilesystemStorageFactory);
         $extension->addStorageFactory(new DoctrineStorageFactory);
+
+        $container->addCompilerPass(new PayumActionsPass);
     }
 }

--- a/Resources/doc/custom_action_usage.md
+++ b/Resources/doc/custom_action_usage.md
@@ -1,0 +1,90 @@
+# Custom action usage
+
+Payment comes with built in actions but sometime you have to add your own. First you have to define a service:
+
+```yaml
+# src/Acme/PaymentBundle/Resources/config/services.yml
+
+services:
+    acme.payum.action.foo:
+        class: Acme\PaymentBundle\Payum\Action\FooAction
+```
+
+There are several ways to add it to a payment:
+
+* Set it explicitly in config.yml. 
+
+    ```yaml
+    # app/config/config.yml
+
+    payum:
+        contexts:
+            a_context:
+                a_factory:
+                    actions:
+                        - acme.payum.action.foo
+    ```
+
+* Tag it
+
+    
+    More powerful method is to add a tag `payum.action` to action server. Payum will do the reset.
+    You can define a `factory` attribute inside that tag. 
+    In this case the action will be added to all payments created by requested factory.
+ 
+    ```yaml
+    # app/config/config.yml
+
+    payum:
+        contexts:
+            a_context:
+                a_factory: ~
+    ```
+
+    ```yaml
+    # src/Acme/PaymentBundle/Resources/config/services.yml
+
+    services:
+        acme.payum.action.foo:
+            class: Acme\PaymentBundle\Payum\Action\FooAction
+            tags:
+                - {payum.action, { factory: a_factory }}
+
+    ```
+
+    Or you can set concrete `context` name. 
+    In this case the action will be added only to the payment with requested context name.
+
+    ```yaml
+    # app/config/config.yml
+
+    payum:
+        contexts:
+            a_context:
+                a_factory: ~
+    ```
+
+    ```yaml
+    # src/Acme/PaymentBundle/Resources/config/services.yml
+
+    services:
+        acme.payum.action.foo:
+            class: Acme\PaymentBundle\Payum\Action\FooAction
+            tags:
+                - {payum.action, {context: a_context}}
+    ```
+
+    If `prepend` set to true the action is added before the rest. 
+    If you want to add the action to all configured payments set `all` to true.
+
+    ```yaml
+    # src/Acme/PaymentBundle/Resources/config/services.yml
+
+    services:
+        acme.payum.action.foo:
+            class: Acme\PaymentBundle\Payum\Action\FooAction
+            tags:
+                - {payum.action, { prepend: true, all: true }}
+    ```
+
+Back to [index](index.md).

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -3,6 +3,7 @@
 * [Get it started](get_it_started.md)
 * [Simple purchase examples](simple_purchase_examples.md).
 * [Purchase done action](purchase_done_action.md).
+* [Custom action usage](custom_action_usage.md).
 * [Custom api usage](custom_api_usage.md).
 * [Sandbox](sandbox.md).
 * [Console commands](console_commands.md).

--- a/Tests/DependencyInjection/Compiler/PayumActionsPassTest.php
+++ b/Tests/DependencyInjection/Compiler/PayumActionsPassTest.php
@@ -1,0 +1,355 @@
+<?php
+namespace Payum\Bundle\PayumBundle\Tests\DependencyInjection\Compiler;
+
+use Payum\Bundle\PayumBundle\DependencyInjection\Compiler\PayumActionsPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+class PayumActionsPassTest extends \Phpunit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldImplementsCompilerPassInteface()
+    {
+        $rc = new \ReflectionClass('Payum\Bundle\PayumBundle\DependencyInjection\Compiler\PayumActionsPass');
+
+        $this->assertTrue($rc->implementsInterface('Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface'));
+    }
+
+    /**
+     * @test
+     */
+    public function couldBeConstructedWithoutAnyArguments()
+    {
+        new PayumActionsPass();
+    }
+
+    /**
+     * @test
+     */
+    public function shouldAddSingleActionToPaymentsByFactoryName()
+    {
+        $container = new ContainerBuilder;
+
+        $paymentFoo = new Definition;
+        $paymentFoo->addTag('payum.payment', array(
+            'factory' => 'foo',
+        ));
+        $container->setDefinition('payment.foo', $paymentFoo);
+
+        $paymentBar = new Definition;
+        $paymentBar->addTag('payum.payment', array(
+            'factory' => 'bar',
+        ));
+        $container->setDefinition('payment.bar', $paymentBar);
+
+        $actionFoo = new Definition;
+        $actionFoo->addTag('payum.action', array(
+            'factory' => 'foo',
+        ));
+        $container->setDefinition('action.foo', $actionFoo);
+
+        $actionBar = new Definition;
+        $actionBar->addTag('payum.action', array(
+            'factory' => 'bar',
+        ));
+        $container->setDefinition('action.bar', $actionBar);
+
+        $pass = new PayumActionsPass;
+
+        $pass->process($container);
+
+        $fooPaymentMethodCalls = $paymentFoo->getMethodCalls();
+        $this->assertCount(1, $fooPaymentMethodCalls);
+        $this->assertEquals('addAction', $fooPaymentMethodCalls[0][0]);
+        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $fooPaymentMethodCalls[0][1][0]);
+        $this->assertEquals('action.foo', (string) $fooPaymentMethodCalls[0][1][0]);
+
+        $barPaymentMethodCalls = $paymentBar->getMethodCalls();
+        $this->assertCount(1, $barPaymentMethodCalls);
+        $this->assertEquals('addAction', $barPaymentMethodCalls[0][0]);
+        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $barPaymentMethodCalls[0][1][0]);
+        $this->assertEquals('action.bar', (string) $barPaymentMethodCalls[0][1][0]);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldAddSeveralActionsToPayment()
+    {
+        $container = new ContainerBuilder;
+
+        $paymentFoo = new Definition;
+        $paymentFoo->addTag('payum.payment', array(
+            'factory' => 'foo',
+        ));
+        $container->setDefinition('payment.foo', $paymentFoo);
+
+        $actionFoo1 = new Definition;
+        $actionFoo1->addTag('payum.action', array(
+            'factory' => 'foo',
+        ));
+        $container->setDefinition('action.foo1', $actionFoo1);
+
+        $actionFoo2 = new Definition;
+        $actionFoo2->addTag('payum.action', array(
+            'factory' => 'foo',
+        ));
+        $container->setDefinition('action.foo2', $actionFoo2);
+
+        $pass = new PayumActionsPass;
+
+        $pass->process($container);
+
+        $fooPaymentMethodCalls = $paymentFoo->getMethodCalls();
+        $this->assertCount(2, $fooPaymentMethodCalls);
+
+        $this->assertEquals('addAction', $fooPaymentMethodCalls[0][0]);
+        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $fooPaymentMethodCalls[0][1][0]);
+        $this->assertEquals('action.foo1', (string) $fooPaymentMethodCalls[0][1][0]);
+
+        $this->assertEquals('addAction', $fooPaymentMethodCalls[1][0]);
+        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $fooPaymentMethodCalls[1][1][0]);
+        $this->assertEquals('action.foo2', (string) $fooPaymentMethodCalls[1][1][0]);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldAddSingleActionWithPrependTrueToPayment()
+    {
+        $container = new ContainerBuilder;
+
+        $paymentFoo = new Definition;
+        $paymentFoo->addTag('payum.payment', array(
+            'factory' => 'foo',
+        ));
+        $container->setDefinition('payment.foo', $paymentFoo);
+
+        $actionFoo = new Definition;
+        $actionFoo->addTag('payum.action', array(
+            'factory' => 'foo', 'prepend' => true
+        ));
+        $container->setDefinition('action.foo', $actionFoo);
+
+        $pass = new PayumActionsPass;
+
+        $pass->process($container);
+
+        $fooPaymentMethodCalls = $paymentFoo->getMethodCalls();
+        $this->assertCount(1, $fooPaymentMethodCalls);
+
+        $this->assertEquals('addAction', $fooPaymentMethodCalls[0][0]);
+        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $fooPaymentMethodCalls[0][1][0]);
+        $this->assertEquals('action.foo', (string) $fooPaymentMethodCalls[0][1][0]);
+        $this->assertTrue($fooPaymentMethodCalls[0][1][1]);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldAddSingleActionWithPrependFalseToPayment()
+    {
+        $container = new ContainerBuilder;
+
+        $paymentFoo = new Definition;
+        $paymentFoo->addTag('payum.payment', array(
+            'factory' => 'foo',
+        ));
+        $container->setDefinition('payment.foo', $paymentFoo);
+
+        $actionFoo = new Definition;
+        $actionFoo->addTag('payum.action', array(
+            'factory' => 'foo', 'prepend' => false
+        ));
+        $container->setDefinition('action.foo', $actionFoo);
+
+        $pass = new PayumActionsPass;
+
+        $pass->process($container);
+
+        $fooPaymentMethodCalls = $paymentFoo->getMethodCalls();
+        $this->assertCount(1, $fooPaymentMethodCalls);
+
+        $this->assertEquals('addAction', $fooPaymentMethodCalls[0][0]);
+        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $fooPaymentMethodCalls[0][1][0]);
+        $this->assertEquals('action.foo', (string) $fooPaymentMethodCalls[0][1][0]);
+        $this->assertFalse($fooPaymentMethodCalls[0][1][1]);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldAddSingleActionToPaymentsByContextName()
+    {
+        $container = new ContainerBuilder;
+
+        $paymentFoo = new Definition;
+        $paymentFoo->addTag('payum.payment', array(
+            'context' => 'foo',
+        ));
+        $container->setDefinition('payment.foo', $paymentFoo);
+
+        $paymentBar = new Definition;
+        $paymentBar->addTag('payum.payment', array(
+            'context' => 'bar',
+        ));
+        $container->setDefinition('payment.bar', $paymentBar);
+
+        $actionFoo = new Definition;
+        $actionFoo->addTag('payum.action', array(
+            'context' => 'foo',
+        ));
+        $container->setDefinition('action.foo', $actionFoo);
+
+        $actionBar = new Definition;
+        $actionBar->addTag('payum.action', array(
+            'context' => 'bar',
+        ));
+        $container->setDefinition('action.bar', $actionBar);
+
+        $pass = new PayumActionsPass;
+
+        $pass->process($container);
+
+        $fooPaymentMethodCalls = $paymentFoo->getMethodCalls();
+        $this->assertCount(1, $fooPaymentMethodCalls);
+        $this->assertEquals('addAction', $fooPaymentMethodCalls[0][0]);
+        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $fooPaymentMethodCalls[0][1][0]);
+        $this->assertEquals('action.foo', (string) $fooPaymentMethodCalls[0][1][0]);
+
+        $barPaymentMethodCalls = $paymentBar->getMethodCalls();
+        $this->assertCount(1, $barPaymentMethodCalls);
+        $this->assertEquals('addAction', $barPaymentMethodCalls[0][0]);
+        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $barPaymentMethodCalls[0][1][0]);
+        $this->assertEquals('action.bar', (string) $barPaymentMethodCalls[0][1][0]);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotAddActionTwiceByFactoryAndContext()
+    {
+        $container = new ContainerBuilder;
+
+        $paymentFoo = new Definition;
+        $paymentFoo->addTag('payum.payment', array(
+            'context' => 'foo_context', 'factory' => 'foo_factory'
+        ));
+        $container->setDefinition('payment.foo', $paymentFoo);
+
+        $actionFoo = new Definition;
+        $actionFoo->addTag('payum.action', array(
+            'context' => 'foo_context', 'factory' => 'foo_factory'
+        ));
+        $container->setDefinition('action.foo', $actionFoo);
+
+        $pass = new PayumActionsPass;
+
+        $pass->process($container);
+
+        $fooPaymentMethodCalls = $paymentFoo->getMethodCalls();
+        $this->assertCount(1, $fooPaymentMethodCalls);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldAddActionToAllPayments()
+    {
+        $container = new ContainerBuilder;
+
+        $paymentFoo = new Definition;
+        $paymentFoo->addTag('payum.payment', array());
+        $container->setDefinition('payment.foo', $paymentFoo);
+
+        $paymentBar = new Definition;
+        $paymentBar->addTag('payum.payment', array());
+        $container->setDefinition('payment.bar', $paymentBar);
+
+        $actionFoo = new Definition;
+        $actionFoo->addTag('payum.action', array(
+            'all' => true
+        ));
+        $container->setDefinition('action.foo', $actionFoo);
+
+        $pass = new PayumActionsPass;
+
+        $pass->process($container);
+
+        $fooPaymentMethodCalls = $paymentFoo->getMethodCalls();
+        $this->assertCount(1, $fooPaymentMethodCalls);
+
+        $barPaymentMethodCalls = $paymentBar->getMethodCalls();
+        $this->assertCount(1, $barPaymentMethodCalls);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotAddActionTwiceIfAllAndFactorySet()
+    {
+        $container = new ContainerBuilder;
+
+        $paymentFoo = new Definition;
+        $paymentFoo->addTag('payum.payment', array(
+            'factory' => 'foo'
+        ));
+        $container->setDefinition('payment.foo', $paymentFoo);
+
+        $paymentBar = new Definition;
+        $paymentBar->addTag('payum.payment', array());
+        $container->setDefinition('payment.bar', $paymentBar);
+
+        $actionFoo = new Definition;
+        $actionFoo->addTag('payum.action', array(
+            'all' => true, 'factory' => 'foo'
+        ));
+        $container->setDefinition('action.foo', $actionFoo);
+
+        $pass = new PayumActionsPass;
+
+        $pass->process($container);
+
+        $fooPaymentMethodCalls = $paymentFoo->getMethodCalls();
+        $this->assertCount(1, $fooPaymentMethodCalls);
+
+        $barPaymentMethodCalls = $paymentBar->getMethodCalls();
+        $this->assertCount(1, $barPaymentMethodCalls);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotAddActionTwiceIfAllAndContextSet()
+    {
+        $container = new ContainerBuilder;
+
+        $paymentFoo = new Definition;
+        $paymentFoo->addTag('payum.payment', array(
+            'context' => 'foo'
+        ));
+        $container->setDefinition('payment.foo', $paymentFoo);
+
+        $paymentBar = new Definition;
+        $paymentBar->addTag('payum.payment', array());
+        $container->setDefinition('payment.bar', $paymentBar);
+
+        $actionFoo = new Definition;
+        $actionFoo->addTag('payum.action', array(
+            'all' => true, 'context' => 'foo'
+        ));
+        $container->setDefinition('action.foo', $actionFoo);
+
+        $pass = new PayumActionsPass;
+
+        $pass->process($container);
+
+        $fooPaymentMethodCalls = $paymentFoo->getMethodCalls();
+        $this->assertCount(1, $fooPaymentMethodCalls);
+
+        $barPaymentMethodCalls = $paymentBar->getMethodCalls();
+        $this->assertCount(1, $barPaymentMethodCalls);
+    }
+}

--- a/Tests/PayumBundleTest.php
+++ b/Tests/PayumBundleTest.php
@@ -1,0 +1,25 @@
+<?php
+namespace Payum\Bundle\PayumBundle\Tests;
+
+use Payum\Bundle\PayumBundle\PayumBundle;
+
+class PayumBundleTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldBeSubClassOfBundle()
+    {
+        $rc = new \ReflectionClass('Payum\Bundle\PayumBundle\PayumBundle');
+
+        $this->assertTrue($rc->isSubclassOf('Symfony\Component\HttpKernel\Bundle\Bundle'));
+    }
+
+    /**
+     * @test
+     */
+    public function couldBeConstructedWithoutAnyArguments()
+    {
+        new PayumBundle;
+    }
+} 


### PR DESCRIPTION
# Custom action usage

Payment comes with built in actions but sometime you have to add your own. First you have to define a service:

``` yaml
# src/Acme/PaymentBundle/Resources/config/services.yml

services:
    acme.payum.action.foo:
        class: Acme\PaymentBundle\Payum\Action\FooAction
```

There are several ways to add it to a payment:
- Set it explicitly in config.yml. 
  
  ``` yaml
  # app/config/config.yml
  
  payum:
      contexts:
          a_context:
              a_factory:
                  actions:
                      - acme.payum.action.foo
  ```
- Tag it
  
  More powerful method is to add a tag `payum.action` to action server. Payum will do the reset.
  You can define a `factory` attribute inside that tag. 
  In this case the action will be added to all payments created by requested factory.
  
  ``` yaml
  # app/config/config.yml
  
  payum:
      contexts:
          a_context:
              a_factory: ~
  ```
  
  ``` yaml
  # src/Acme/PaymentBundle/Resources/config/services.yml
  
  services:
      acme.payum.action.foo:
          class: Acme\PaymentBundle\Payum\Action\FooAction
          tags:
              - {payum.action, { factory: a_factory }}
  
  ```
  
  Or you can set concrete `context` name. 
  In this case the action will be added only to the payment with requested context name.
  
  ``` yaml
  # app/config/config.yml
  
  payum:
      contexts:
          a_context:
              a_factory: ~
  ```
  
  ``` yaml
  # src/Acme/PaymentBundle/Resources/config/services.yml
  
  services:
      acme.payum.action.foo:
          class: Acme\PaymentBundle\Payum\Action\FooAction
          tags:
              - {payum.action, {context: a_context}}
  ```
  
  If `prepend` set to true the action is added before the rest. 
  If you want to add the action to all configured payments set `all` to true.
  
  ``` yaml
  # src/Acme/PaymentBundle/Resources/config/services.yml
  
  services:
      acme.payum.action.foo:
          class: Acme\PaymentBundle\Payum\Action\FooAction
          tags:
              - {payum.action, { prepend: true, all: true }}
  ```

Back to [index](index.md).
