### PR TITLE
[config] add templates section.

### DIFF
--- a/DependencyInjection/PayumExtension.php
+++ b/DependencyInjection/PayumExtension.php
@@ -32,6 +32,8 @@ class PayumExtension extends Extension implements PrependExtensionInterface
         $mainConfig = $this->getConfiguration($configs, $container);
 
         $config = $this->processConfiguration($mainConfig, $configs);
+        $container->setParameter('payum.template.layout', $config['templates']['layout']);
+        $container->setParameter('payum.template.obtain_credit_card', $config['templates']['obtain_credit_card']);
 
         // load services
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
@@ -51,7 +53,7 @@ class PayumExtension extends Extension implements PrependExtensionInterface
             'paths' => array(
                 TwigFactory::guessViewsPath('Payum\Core\Payment') => 'PayumCore',
                 TwigFactory::guessViewsPath('Payum\Core\Bridge\Symfony\ReplyToSymfonyResponseConverter') => 'PayumSymfonyBridge',
-            )
+            ),
         ));
 
         foreach ($this->paymentFactories as $factory) {
@@ -62,7 +64,7 @@ class PayumExtension extends Extension implements PrependExtensionInterface
     }
 
     /**
-     * @param array $config
+     * @param array            $config
      * @param ContainerBuilder $container
      */
     protected function loadContexts(array $config, ContainerBuilder $container)
@@ -85,7 +87,7 @@ class PayumExtension extends Extension implements PrependExtensionInterface
 
             $container->getDefinition($paymentId)->addTag('payum.payment', array(
                 'factory' => $paymentFactoryName,
-                'context' => $contextName
+                'context' => $contextName,
             ));
         }
 
@@ -95,7 +97,7 @@ class PayumExtension extends Extension implements PrependExtensionInterface
     }
 
     /**
-     * @param array $config
+     * @param array            $config
      * @param ContainerBuilder $container
      */
     protected function loadStorages(array $config, ContainerBuilder $container)
@@ -130,7 +132,7 @@ class PayumExtension extends Extension implements PrependExtensionInterface
     }
 
     /**
-     * @param array $securityConfig
+     * @param array            $securityConfig
      * @param ContainerBuilder $container
      */
     protected function loadSecurity(array $securityConfig, ContainerBuilder $container)
@@ -162,7 +164,7 @@ class PayumExtension extends Extension implements PrependExtensionInterface
         if (array_key_exists($factoryName, $this->storageFactories)) {
             throw new InvalidArgumentException(sprintf('The storage factory with such name %s already registered', $factoryName));
         }
-        
+
         $this->storageFactories[$factoryName] = $factory;
     }
 
@@ -180,7 +182,7 @@ class PayumExtension extends Extension implements PrependExtensionInterface
         if (isset($this->paymentFactories[$factoryName])) {
             throw new InvalidArgumentException(sprintf('The payment factory with such name %s already registered', $factoryName));
         }
-        
+
         $this->paymentFactories[$factory->getName()] = $factory;
     }
 

--- a/Resources/config/payum.xml
+++ b/Resources/config/payum.xml
@@ -22,9 +22,6 @@
 
         <parameter key="payum.security.http_request_verifier.class">Payum\Core\Bridge\Symfony\Security\HttpRequestVerifier</parameter>
         <parameter key="payum.security.token_factory.class">Payum\Core\Bridge\Symfony\Security\TokenFactory</parameter>
-
-        <parameter key="payum.template.layout">@PayumCore\layout.html.twig</parameter>
-        <parameter key="payum.template.obtain_credit_card">@PayumSymfonyBridge\obtainCreditCard.html.twig</parameter>
     </parameters>
 
     <services>
@@ -50,8 +47,8 @@
             public="false"
         />
 
-        <service 
-            id="payum.extension.storage.prototype" 
+        <service
+            id="payum.extension.storage.prototype"
             class="%payum.extension.storage.class%"
             abstract="true"
             public="false"

--- a/Tests/DependencyInjection/MainConfigurationTest.php
+++ b/Tests/DependencyInjection/MainConfigurationTest.php
@@ -13,19 +13,19 @@ class MainConfigurationTest extends  \PHPUnit_Framework_TestCase
     protected $paymentFactories = array();
 
     protected $storageFactories = array();
-    
+
     protected function setUp()
     {
         $this->paymentFactories = array(
             new FooPaymentFactory(),
-            new BarPaymentFactory()
+            new BarPaymentFactory(),
         );
         $this->storageFactories = array(
             new FooStorageFactory(),
-            new BarStorageFactory()
+            new BarStorageFactory(),
         );
     }
-    
+
     /**
      * @test
      */
@@ -40,43 +40,47 @@ class MainConfigurationTest extends  \PHPUnit_Framework_TestCase
     public function shouldPassConfigurationProcessing()
     {
         $configuration = new MainConfiguration($this->paymentFactories, $this->storageFactories);
-        
+
         $processor = new Processor();
-        
+
         $fooModelClass = get_class($this->getMock('stdClass'));
         $barModelClass = get_class($this->getMock('stdClass'));
 
         $processor->processConfiguration($configuration, array(
             'payum' => array(
+                'templates' => array(
+                    'layout' => 'layout.html.twig',
+                    'obtain_credit_card' => 'payment\obtainCreditCard.html.twig',
+                ),
                 'storages' => array(
                     $fooModelClass => array(
                         'bar_storage' => array(
-                            'bar_opt' => 'bar'
+                            'bar_opt' => 'bar',
                         ),
                     ),
                     $barModelClass => array(
                         'bar_storage' => array(
-                            'bar_opt' => 'bar'
+                            'bar_opt' => 'bar',
                         ),
-                    )
+                    ),
                 ),
                 'security' => array(
                     'token_storage' => array(
                         'Payum\Core\Model\Token' => array(
                             'foo_storage' => array(
-                                'foo_opt' => 'foo'
-                            )
-                        )
-                    )
+                                'foo_opt' => 'foo',
+                            ),
+                        ),
+                    ),
                 ),
                 'contexts' => array(
                     'a_context' => array(
-                        'foo_payment' => array( 
-                            'foo_opt' => 'foo'
+                        'foo_payment' => array(
+                            'foo_opt' => 'foo',
                         ),
-                    )
-                )
-            )
+                    ),
+                ),
+            ),
         ));
     }
 
@@ -96,7 +100,7 @@ class MainConfigurationTest extends  \PHPUnit_Framework_TestCase
                 'storages' => array(
                     $fooModelClass => array(
                         'bar_storage' => array(
-                            'bar_opt' => 'bar'
+                            'bar_opt' => 'bar',
                         ),
                     ),
                 ),
@@ -104,12 +108,12 @@ class MainConfigurationTest extends  \PHPUnit_Framework_TestCase
                     'token_storage' => array(
                         'Payum\Core\Model\Token' => array(
                             'foo_storage' => array(
-                                'foo_opt' => 'foo'
-                            )
-                        )
-                    )
+                                'foo_opt' => 'foo',
+                            ),
+                        ),
+                    ),
                 ),
-            )
+            ),
         ));
 
         $this->assertTrue(isset($config['storages'][$fooModelClass]['payment']['all']));
@@ -141,7 +145,7 @@ class MainConfigurationTest extends  \PHPUnit_Framework_TestCase
                             'all' => false,
                         ),
                         'bar_storage' => array(
-                            'bar_opt' => 'bar'
+                            'bar_opt' => 'bar',
                         ),
                     ),
                 ),
@@ -149,12 +153,12 @@ class MainConfigurationTest extends  \PHPUnit_Framework_TestCase
                     'token_storage' => array(
                         'Payum\Core\Model\Token' => array(
                             'foo_storage' => array(
-                                'foo_opt' => 'foo'
-                            )
-                        )
-                    )
+                                'foo_opt' => 'foo',
+                            ),
+                        ),
+                    ),
                 ),
-            )
+            ),
         ));
 
         $this->assertTrue(isset($config['storages'][$fooModelClass]['payment']['all']));
@@ -178,11 +182,11 @@ class MainConfigurationTest extends  \PHPUnit_Framework_TestCase
                     $fooModelClass => array(
                         'payment' => array(
                             'contexts' => array(
-                                'foo', 'bar'
-                            )
+                                'foo', 'bar',
+                            ),
                         ),
                         'bar_storage' => array(
-                            'bar_opt' => 'bar'
+                            'bar_opt' => 'bar',
                         ),
                     ),
                 ),
@@ -190,12 +194,12 @@ class MainConfigurationTest extends  \PHPUnit_Framework_TestCase
                     'token_storage' => array(
                         'Payum\Core\Model\Token' => array(
                             'foo_storage' => array(
-                                'foo_opt' => 'foo'
-                            )
-                        )
-                    )
+                                'foo_opt' => 'foo',
+                            ),
+                        ),
+                    ),
                 ),
-            )
+            ),
         ));
 
         $this->assertTrue(isset($config['storages'][$fooModelClass]['payment']['contexts']));
@@ -219,11 +223,11 @@ class MainConfigurationTest extends  \PHPUnit_Framework_TestCase
                     $fooModelClass => array(
                         'payment' => array(
                             'factories' => array(
-                                'foo', 'bar'
-                            )
+                                'foo', 'bar',
+                            ),
                         ),
                         'bar_storage' => array(
-                            'bar_opt' => 'bar'
+                            'bar_opt' => 'bar',
                         ),
                     ),
                 ),
@@ -231,12 +235,12 @@ class MainConfigurationTest extends  \PHPUnit_Framework_TestCase
                     'token_storage' => array(
                         'Payum\Core\Model\Token' => array(
                             'foo_storage' => array(
-                                'foo_opt' => 'foo'
-                            )
-                        )
-                    )
+                                'foo_opt' => 'foo',
+                            ),
+                        ),
+                    ),
                 ),
-            )
+            ),
         ));
 
         $this->assertTrue(isset($config['storages'][$fooModelClass]['payment']['factories']));
@@ -245,7 +249,7 @@ class MainConfigurationTest extends  \PHPUnit_Framework_TestCase
 
     /**
      * @test
-     * 
+     *
      * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      * @expectedExceptionMessage Invalid configuration for path "payum.storages": The storage entry must be a valid model class. It is set notExistClass
      */
@@ -260,7 +264,7 @@ class MainConfigurationTest extends  \PHPUnit_Framework_TestCase
                 'storages' => array(
                     'notExistClass' => array(
                         'foo_storage' => array(
-                            'foo_opt' => 'bar'
+                            'foo_opt' => 'bar',
                         ),
                     ),
                 ),
@@ -268,25 +272,25 @@ class MainConfigurationTest extends  \PHPUnit_Framework_TestCase
                     'token_storage' => array(
                         'Payum\Core\Model\Token' => array(
                             'foo_storage' => array(
-                                'foo_opt' => 'foo'
-                            )
-                        )
-                    )
+                                'foo_opt' => 'foo',
+                            ),
+                        ),
+                    ),
                 ),
                 'contexts' => array(
                     'a_context' => array(
                         'foo_payment' => array(
-                            'foo_opt' => 'foo'
+                            'foo_opt' => 'foo',
                         ),
-                    )
-                )
-            )
+                    ),
+                ),
+            ),
         ));
     }
 
     /**
      * @test
-     * 
+     *
      * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      * @expectedExceptionMessage Invalid configuration for path "payum.storages.stdClass": Only one storage per entry could be selected
      */
@@ -301,30 +305,30 @@ class MainConfigurationTest extends  \PHPUnit_Framework_TestCase
                 'storages' => array(
                     'stdClass' => array(
                         'foo_storage' => array(
-                            'foo_opt' => 'bar'
+                            'foo_opt' => 'bar',
                         ),
                         'bar_storage' => array(
-                            'bar_opt' => 'bar'
-                        )
+                            'bar_opt' => 'bar',
+                        ),
                     ),
                 ),
                 'security' => array(
                     'token_storage' => array(
                         'Payum\Core\Model\Token' => array(
                             'foo_storage' => array(
-                                'foo_opt' => 'foo'
-                            )
-                        )
-                    )
+                                'foo_opt' => 'foo',
+                            ),
+                        ),
+                    ),
                 ),
                 'contexts' => array(
                     'a_context' => array(
                         'foo_payment' => array(
-                            'foo_opt' => 'foo'
+                            'foo_opt' => 'foo',
                         ),
-                    )
-                )
-            )
+                    ),
+                ),
+            ),
         ));
     }
 
@@ -349,25 +353,25 @@ class MainConfigurationTest extends  \PHPUnit_Framework_TestCase
                     'token_storage' => array(
                         'Payum\Core\Model\Token' => array(
                             'foo_storage' => array(
-                                'foo_opt' => 'foo'
-                            )
-                        )
-                    )
+                                'foo_opt' => 'foo',
+                            ),
+                        ),
+                    ),
                 ),
                 'contexts' => array(
                     'a_context' => array(
                         'foo_payment' => array(
-                            'foo_opt' => 'foo'
+                            'foo_opt' => 'foo',
                         ),
-                    )
-                )
-            )
+                    ),
+                ),
+            ),
         ));
     }
 
     /**
      * @test
-     * 
+     *
      * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      * @expectedExceptionMessage Invalid configuration for path "payum.contexts.a_context": One payment from the  payments available must be selected
      */
@@ -383,15 +387,15 @@ class MainConfigurationTest extends  \PHPUnit_Framework_TestCase
                     'token_storage' => array(
                         'Payum\Core\Model\Token' => array(
                             'foo_storage' => array(
-                                'foo_opt' => 'foo'
-                            )
-                        )
-                    )
+                                'foo_opt' => 'foo',
+                            ),
+                        ),
+                    ),
                 ),
                 'contexts' => array(
-                    'a_context' => array()
-                )
-            )
+                    'a_context' => array(),
+                ),
+            ),
         ));
     }
 
@@ -410,19 +414,19 @@ class MainConfigurationTest extends  \PHPUnit_Framework_TestCase
                     'token_storage' => array(
                         'Payum\Core\Model\Token' => array(
                             'foo_storage' => array(
-                                'foo_opt' => 'foo'
-                            )
-                        )
-                    )
+                                'foo_opt' => 'foo',
+                            ),
+                        ),
+                    ),
                 ),
                 'contexts' => array(
                     'a_context' => array(
                         'foo_payment' => array(
-                            'foo_opt' => 'foo'
-                        )
-                    )
-                )
-            )
+                            'foo_opt' => 'foo',
+                        ),
+                    ),
+                ),
+            ),
         ));
     }
 
@@ -444,22 +448,22 @@ class MainConfigurationTest extends  \PHPUnit_Framework_TestCase
                     'token_storage' => array(
                         'Payum\Core\Model\Token' => array(
                             'foo_storage' => array(
-                                'foo_opt' => 'foo'
-                            )
-                        )
-                    )
+                                'foo_opt' => 'foo',
+                            ),
+                        ),
+                    ),
                 ),
                 'contexts' => array(
                     'a_context' => array(
                         'bar_payment' => array(
-                            'bar_opt' => 'bar'
+                            'bar_opt' => 'bar',
                         ),
                         'foo_payment' => array(
-                            'foo_opt' => 'foo'
-                        )
-                    )
-                )
-            )
+                            'foo_opt' => 'foo',
+                        ),
+                    ),
+                ),
+            ),
         ));
     }
 
@@ -481,24 +485,24 @@ class MainConfigurationTest extends  \PHPUnit_Framework_TestCase
                     'token_storage' => array(
                         'Payum\Core\Model\Token' => array(
                             'foo_storage' => array(
-                                'foo_opt' => 'foo'
-                            )
+                                'foo_opt' => 'foo',
+                            ),
                         ),
                         'stdClass' => array(
                             'foo_storage' => array(
-                                'foo_opt' => 'foo'
-                            )
-                        )
-                    )
+                                'foo_opt' => 'foo',
+                            ),
+                        ),
+                    ),
                 ),
                 'contexts' => array(
                     'a_context' => array(
                         'foo_payment' => array(
-                            'foo_opt' => 'foo'
+                            'foo_opt' => 'foo',
                         ),
-                    )
-                )
-            )
+                    ),
+                ),
+            ),
         ));
     }
 
@@ -520,19 +524,19 @@ class MainConfigurationTest extends  \PHPUnit_Framework_TestCase
                     'token_storage' => array(
                         'stdClass' => array(
                             'foo_storage' => array(
-                                'foo_opt' => 'foo'
-                            )
-                        )
-                    )
+                                'foo_opt' => 'foo',
+                            ),
+                        ),
+                    ),
                 ),
                 'contexts' => array(
                     'a_context' => array(
                         'foo_payment' => array(
-                            'foo_opt' => 'foo'
+                            'foo_opt' => 'foo',
                         ),
-                    )
-                )
-            )
+                    ),
+                ),
+            ),
         ));
     }
 
@@ -554,19 +558,19 @@ class MainConfigurationTest extends  \PHPUnit_Framework_TestCase
                     'token_storage' => array(
                         'foo' => array(
                             'foo_storage' => array(
-                                'foo_opt' => 'foo'
-                            )
-                        )
-                    )
+                                'foo_opt' => 'foo',
+                            ),
+                        ),
+                    ),
                 ),
                 'contexts' => array(
                     'a_context' => array(
                         'foo_payment' => array(
-                            'foo_opt' => 'foo'
+                            'foo_opt' => 'foo',
                         ),
-                    )
-                )
-            )
+                    ),
+                ),
+            ),
         ));
     }
 
@@ -587,11 +591,11 @@ class MainConfigurationTest extends  \PHPUnit_Framework_TestCase
                 'contexts' => array(
                     'a_context' => array(
                         'foo_payment' => array(
-                            'foo_opt' => 'foo'
+                            'foo_opt' => 'foo',
                         ),
-                    )
-                )
-            )
+                    ),
+                ),
+            ),
         ));
     }
 
@@ -614,11 +618,11 @@ class MainConfigurationTest extends  \PHPUnit_Framework_TestCase
                 'contexts' => array(
                     'a_context' => array(
                         'foo_payment' => array(
-                            'foo_opt' => 'foo'
+                            'foo_opt' => 'foo',
                         ),
-                    )
-                )
-            )
+                    ),
+                ),
+            ),
         ));
     }
 }


### PR DESCRIPTION
This allow to override default payum templates in config file here is an example:

```yaml
payum:
    templates:
            layout: layout.html.twig
            obtain_credit_card: payment\obtainCreditCard.html.twig
