### PR TITLE
Bump Stripe API to version 2.1.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,12 @@
             "homepage": "https://github.com/Payum/PayumBundle/contributors"
         }
     ],
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/ChessCom/Payum"
+        }
+    ],
     "require": {
         "php": ">=5.3.2",
         "payum/core": "0.14.*",
@@ -52,7 +58,7 @@
         "symfony/class-loader": "~2.3",
         "sonata-project/admin-bundle": "~2.0",
         "doctrine/orm": "*",
-        "payum/payum": "0.14.*",
+        "payum/payum": "0.14-stripe-v2.1.3",
         "payum/omnipay-bridge": "0.14.*",
         "payum/jms-payment-bridge": "0.14.*",
         "omnipay/dummy": "~2.0",


### PR DESCRIPTION
Investigating updating the Stripe API version in Payum

## End Objective
Latest Stripe API in Payum 1.x

## First step
Testing 2.1.3 in .14

## Next steps
Either 2.1.3 in Payum 1.x or directly latest Stripe in Payum 1.x

## Why 2.1.3?
`Network requests are now done through a swappable class for easier mocking` https://github.com/stripe/stripe-php/blob/v2.1.3/CHANGELOG.md