### PR TITLE
Assign channel to loggers

### DIFF
--- a/Resources/config/debug.xml
+++ b/Resources/config/debug.xml
@@ -10,6 +10,7 @@
         <service id="payum.extension.log_executed_actions" class="Payum\Core\Bridge\Psr\Log\LogExecutedActionsExtension">
             <argument type="service" id="logger" on-invalid="ignore" />
 
+            <tag name="monolog.logger" channel="payum"/>
             <tag name="payum.extension" all="true" alias="log_executed_actions" />
         </service>
     </services>

--- a/Resources/config/payum.xml
+++ b/Resources/config/payum.xml
@@ -75,6 +75,7 @@
         <service id="payum.extension.logger" class="Payum\Core\Bridge\Psr\Log\LoggerExtension">
             <argument type="service" id="logger" on-invalid="ignore" />
 
+            <tag name="monolog.logger" channel="payum"/>
             <tag name="payum.extension" all="true" alias="psr_logger" />
         </service>
 


### PR DESCRIPTION
With a dedicated log channels it's easier to write logs to a different
location.

See http://symfony.com/doc/current/reference/dic_tags.html#dic-tags-monolog