### PR TITLE
improve documentation for config reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ payum:
 
     security:
         token_storage:
-            Payum\Core\Model\Token:
-                storage_dir: %kernel.root_dir%/Resources/gateways
-                id_property: hash
+            filesystem:
+                Payum\Core\Model\Token:
+                    storage_dir: %kernel.root_dir%/Resources/gateways
+                    id_property: hash
                 
     gateways:
         offline:

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ payum:
 
     security:
         token_storage:
-            filesystem:
-                Payum\Core\Model\Token:
+            Payum\Core\Model\Token:
+                filesystem:
                     storage_dir: %kernel.root_dir%/Resources/gateways
                     id_property: hash
                 


### PR DESCRIPTION
I fixed the default configuration cause you didn't defined any token storage for security section