### PR TITLE
[security] Add support of Gateway encryption.

### DIFF
--- a/DependencyInjection/MainConfiguration.php
+++ b/DependencyInjection/MainConfiguration.php
@@ -242,6 +242,12 @@ class MainConfiguration implements ConfigurationInterface
             ->end()
         ;
 
+        $dynamicGatewaysNode->children()
+            ->arrayNode('encryption')
+                ->children()
+                    ->scalarNode('defuse_secret_key')->cannotBeEmpty()->end()
+        ;
+
         foreach ($this->storageFactories as $factory) {
             $factory->addConfiguration(
                 $storageNode->children()->arrayNode($factory->getName())

--- a/Sonata/GatewayConfigAdmin.php
+++ b/Sonata/GatewayConfigAdmin.php
@@ -1,13 +1,15 @@
 <?php
 namespace Payum\Bundle\PayumBundle\Sonata;
 
-use Sonata\AdminBundle\Admin\Admin;
+use Payum\Core\Security\CryptedInterface;
+use Payum\Core\Security\CypherInterface;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 use Symfony\Component\Form\FormFactoryInterface;
 use Payum\Core\Bridge\Symfony\Form\Type\GatewayConfigType;
 
-class GatewayConfigAdmin extends Admin
+class GatewayConfigAdmin extends AbstractAdmin
 {
     /**
      * @var FormFactoryInterface
@@ -15,11 +17,24 @@ class GatewayConfigAdmin extends Admin
     protected $formFactory;
 
     /**
+     * @var CypherInterface|null
+     */
+    protected $cypher;
+
+    /**
      * @param FormFactoryInterface $formFactory
      */
     public function setFormFactory(FormFactoryInterface $formFactory)
     {
         $this->formFactory = $formFactory;
+    }
+
+    /**
+     * @param CypherInterface $cypher
+     */
+    public function setCypher(CypherInterface $cypher)
+    {
+        $this->cypher = $cypher;
     }
 
     /**
@@ -46,6 +61,44 @@ class GatewayConfigAdmin extends Admin
                 )
             ))
         ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function preUpdate($object)
+    {
+        parent::preUpdate($object);
+
+        if ($this->cypher && $object instanceof CryptedInterface) {
+            $object->encrypt($this->cypher);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function prePersist($object)
+    {
+        parent::prePersist($object);
+
+        if ($this->cypher && $object instanceof CryptedInterface) {
+            $object->encrypt($this->cypher);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getObject($id)
+    {
+        $object = parent::getObject($id);
+
+        if ($this->cypher && $object instanceof CryptedInterface) {
+            $object->decrypt($this->cypher);
+        }
+
+        return $object;
     }
 
     /**

--- a/Tests/Functional/DependencyInjection/MainConfigurationTest.php
+++ b/Tests/Functional/DependencyInjection/MainConfigurationTest.php
@@ -115,6 +115,43 @@ class MainConfigurationTest extends  \PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function shouldPassConfigurationProcessingWithDynamicGatewaysAndEncryption()
+    {
+        $configuration = new MainConfiguration($this->storageFactories);
+
+        $processor = new Processor();
+
+        $processor->processConfiguration($configuration, array(
+            'payum' => array(
+                'security' => array(
+                    'token_storage' => array(
+                        'Payum\Core\Model\Token' => array(
+                            'filesystem' => array(
+                                'storage_dir' => sys_get_temp_dir(),
+                                'id_property' => 'hash'
+                            )
+                        )
+                    )
+                ),
+                'dynamic_gateways' => array(
+                    'encryption' => [
+                        'defuse_secret_key' =>  'aSecretKey',
+                    ],
+                    'config_storage' => array(
+                        'Payum\Core\Model\GatewayConfig' => array(
+                            'doctrine' => array(
+                                'driver' => 'aDriver',
+                            )
+                        ),
+                    ),
+                )
+            )
+        ));
+    }
+
+    /**
+     * @test
+     */
     public function shouldPassConfigurationProcessingWithDynamicGatewaysPlusSonataAdmin()
     {
         $configuration = new MainConfiguration($this->storageFactories);

--- a/Tests/Functional/app/config/config.yml
+++ b/Tests/Functional/app/config/config.yml
@@ -16,6 +16,7 @@ framework:
     form:                                                 true
     csrf_protection:                                      true
     validation:                                           { enable_annotations: true }
+    assets: false
 
 payum:
     storages:

--- a/Tests/Sonata/GatewayConfigAdminTest.php
+++ b/Tests/Sonata/GatewayConfigAdminTest.php
@@ -2,6 +2,8 @@
 namespace Payum\Bundle\PayumBundle\Sonata\Tests;
 
 use Payum\Bundle\PayumBundle\Sonata\GatewayConfigAdmin;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Symfony\Component\Form\FormFactoryInterface;
 
 class GatewayConfigAdminTest extends \PHPUnit_Framework_TestCase
 {
@@ -10,9 +12,9 @@ class GatewayConfigAdminTest extends \PHPUnit_Framework_TestCase
      */
     public function shouldBeSubClassSonataAdmin()
     {
-        $rc = new \ReflectionClass('Payum\Bundle\PayumBundle\Sonata\GatewayConfigAdmin');
+        $rc = new \ReflectionClass(GatewayConfigAdmin::class);
 
-        $this->assertTrue($rc->isSubclassOf('Sonata\AdminBundle\Admin\Admin'));
+        $this->assertTrue($rc->isSubclassOf(AbstractAdmin::class));
     }
 
     /**
@@ -30,7 +32,7 @@ class GatewayConfigAdminTest extends \PHPUnit_Framework_TestCase
     {
         $admin = new GatewayConfigAdmin('code', 'class', 'baseControllerName');
 
-        $formFactoryMock = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactoryMock = $this->getMock(FormFactoryInterface::class);
 
         $admin->setFormFactory($formFactoryMock);
 

--- a/composer.json
+++ b/composer.json
@@ -46,12 +46,14 @@
     "require-dev": {
         "phpunit/phpunit": "~4.0",
         "twig/twig": "~1.16|~2.0",
+        "symfony/twig-bundle": "^2.8|^3",
         "symfony/expression-language": "~2.8|~3.0",
         "symfony/browser-kit": "~2.8|~3.0",
         "symfony/security-acl": "~2.8|~3.0",
         "symfony/class-loader": "~2.8|~3.0",
         "symfony/phpunit-bridge": "~2.8|~3.0",
-        "sonata-project/admin-bundle": "~2.4@dev",
+        "sonata-project/admin-bundle": "^3",
+        "defuse/php-encryption": "^2",
         "doctrine/orm": "~2.5",
         "payum/payum": "^1.4@dev",
         "payum/omnipay-bridge": "^1@dev",
@@ -71,7 +73,7 @@
         "ext-soap": "*"
     },
     "suggest": {
-        "sonata-project/admin-bundle": "~2.4 If you want to configure payments in the backend."
+        "sonata-project/admin-bundle": "^3 If you want to configure payments in the backend."
     },
     "autoload": {
         "psr-4": { "Payum\\Bundle\\PayumBundle\\": "" }

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     ],
     "require": {
         "php": "^5.5.0|^7.0",
-        "payum/core": "^1.3.7",
+        "payum/core": "^1.4",
         "symfony/framework-bundle": "~2.8|~3.0",
         "symfony/form": "~2.8|~3.0",
         "symfony/validator": "~2.8|~3.0"
@@ -53,7 +53,7 @@
         "symfony/phpunit-bridge": "~2.8|~3.0",
         "sonata-project/admin-bundle": "~2.4@dev",
         "doctrine/orm": "~2.5",
-        "payum/payum": "^1.3.7@dev",
+        "payum/payum": "^1.4@dev",
         "payum/omnipay-bridge": "^1@dev",
         "payum/jms-payment-bridge": "^1@dev",
 
@@ -78,7 +78,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.1-dev"
+            "dev-master": "2.2-dev"
         }
     },
     "config": {


### PR DESCRIPTION
based on https://github.com/Payum/Payum/pull/641

config example:

```yaml
payum:
    dynamic_gateways:
        encryption:
            defuse_secret_key: '%defuse.secert_key%'
        config_storage:
            Acme\PaymentBundle\Entity\GatewayConfig: { doctrine: orm }
```
