### PR TITLE
Remove deprecated 'strict' attribute

### DIFF
--- a/Resources/config/payum.xml
+++ b/Resources/config/payum.xml
@@ -85,10 +85,10 @@
 
         <service id="payum.action.get_http_request" class="Payum\Core\Bridge\Symfony\Action\GetHttpRequestAction">
             <call method="setHttpRequest">
-                <argument type="service" id="request" on-invalid="null" strict="false" />
+                <argument type="service" id="request" on-invalid="null" />
             </call>
             <call method="setHttpRequestStack">
-                <argument type="service" id="request_stack" on-invalid="null" strict="false" />
+                <argument type="service" id="request_stack" on-invalid="null" />
             </call>
         </service>
 


### PR DESCRIPTION
The "strict" attribute used when referencing the "request" service is deprecated since version 3.3 and will be removed in 4.0.
Hide trace
{▼
  /vendor/symfony/symfony/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php:488: {▼
    : if ($arg->hasAttribute('strict')) {
    :     @trigger_error(sprintf('The "strict" attribute used when referencing the "%s" service is deprecated since version 3.3 and will be removed in 4.0.', $arg->getAttribute('id')), E_USER_DEPRECATED);