### PR TITLE
Add specific payum3x.xml configuration to avoid deprecation warnings

### DIFF
--- a/DependencyInjection/PayumExtension.php
+++ b/DependencyInjection/PayumExtension.php
@@ -17,6 +17,7 @@ use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\Config\FileLocator;
 
@@ -39,6 +40,7 @@ class PayumExtension extends Extension implements PrependExtensionInterface
         // load services
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('payum.xml');
+        $loader->load(Kernel::MAJOR_VERSION === 3 ? 'payum3x.xml' : 'payum2x.xml');
         $loader->load('form.xml');
 
         if ($container->getParameter('kernel.debug')) {

--- a/Resources/config/payum.xml
+++ b/Resources/config/payum.xml
@@ -81,17 +81,6 @@
             <tag name="payum.extension" all="true" alias="psr_logger" />
         </service>
 
-        <!-- Actions -->
-
-        <service id="payum.action.get_http_request" class="Payum\Core\Bridge\Symfony\Action\GetHttpRequestAction">
-            <call method="setHttpRequest">
-                <argument type="service" id="request" on-invalid="null" strict="false" />
-            </call>
-            <call method="setHttpRequestStack">
-                <argument type="service" id="request_stack" on-invalid="null" strict="false" />
-            </call>
-        </service>
-
         <!-- Builders -->
         <service id="payum.token_factory_builder" class="Payum\Core\Bridge\Symfony\Builder\TokenFactoryBuilder" public="false">
             <argument type="service" id="router" />

--- a/Resources/config/payum2x.xml
+++ b/Resources/config/payum2x.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <!-- Actions -->
+
+        <service id="payum.action.get_http_request" class="Payum\Core\Bridge\Symfony\Action\GetHttpRequestAction">
+            <call method="setHttpRequest">
+                <argument type="service" id="request" on-invalid="null" strict="false" />
+            </call>
+            <call method="setHttpRequestStack">
+                <argument type="service" id="request_stack" on-invalid="null" strict="false" />
+            </call>
+        </service>
+    </services>
+</container>

--- a/Resources/config/payum3x.xml
+++ b/Resources/config/payum3x.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <!-- Actions -->
+
+        <service id="payum.action.get_http_request" class="Payum\Core\Bridge\Symfony\Action\GetHttpRequestAction">
+            <call method="setHttpRequestStack">
+                <argument type="service" id="request_stack" />
+            </call>
+        </service>
+    </services>
+</container>


### PR DESCRIPTION
As mentioned in #422, the service `payum.action.get_http_request` generate 2 deprecation warning because of the `strict` attribute being deprecated starting from Symfony3.3.

This change the `PayumExtension->load` so it load an alternative version of the `payum.xml` file when using Symfony3+.