### PR TITLE
Fix PayumExtension to only load orm when it is available

### DIFF
--- a/DependencyInjection/PayumExtension.php
+++ b/DependencyInjection/PayumExtension.php
@@ -70,7 +70,7 @@ class PayumExtension extends Extension implements PrependExtensionInterface
         if (isset($bundles['DoctrineBundle'])) {
             foreach ($container->getExtensionConfig('doctrine') as $config) {
                 // do not register mappings if dbal not configured.
-                if (false == empty($config['dbal'])) {
+                if (false == empty($config['dbal']) && false == empty($config['orm'])) {
                     $rc = new \ReflectionClass(Gateway::class);
                     $payumRootDir = dirname($rc->getFileName());
 

--- a/Tests/DependencyInjection/PayumExtensionTest.php
+++ b/Tests/DependencyInjection/PayumExtensionTest.php
@@ -137,7 +137,8 @@ class PayumExtensionTest extends  \PHPUnit_Framework_TestCase
 
         $container->prependExtensionConfig('doctrine', array());
         $container->prependExtensionConfig('doctrine', array(
-            'dbal' => 'not empty'
+            'dbal' => 'not empty',
+            'orm' => 'not empty'
         ));
 
         $extension->prepend($container);
@@ -157,7 +158,10 @@ class PayumExtensionTest extends  \PHPUnit_Framework_TestCase
                         )
                     )),
                 ),
-                array('dbal' => 'not empty'),
+                array(
+                    'dbal' => 'not empty',
+                    'orm' => 'not empty'
+                ),
                 array(),
             ),
             $container->getExtensionConfig('doctrine')


### PR DESCRIPTION
Without this fix, Payum assumes, that the Doctrine bundle always comes with Doctrine ORM. But that is not always the case. Symfony will throw a LogicException in that case:
"To configure the ORM layer, you must first install the doctrine/orm package."

So it make sense to check if Doctrine ORM is available and only prepend the ExtensionConfig if that is the case.