### PR TITLE
Set up commands names to be compatibile with Symfony 3.3

### DIFF
--- a/Command/CreateCaptureTokenCommand.php
+++ b/Command/CreateCaptureTokenCommand.php
@@ -19,6 +19,7 @@ class CreateCaptureTokenCommand extends ContainerAwareCommand
     protected function configure()
     {
         $this
+            ->setName(static::$defaultName)
             ->addArgument('gateway-name', InputArgument::REQUIRED, 'The gateway name associated with the token')
             ->addOption('model-class', null, InputOption::VALUE_OPTIONAL, 'The model class associated with the token')
             ->addOption('model-id', null, InputOption::VALUE_OPTIONAL, 'The model id associated with the token')
@@ -63,4 +64,4 @@ class CreateCaptureTokenCommand extends ContainerAwareCommand
     {
         return $this->getContainer()->get('payum');
     }
-} 
+}

--- a/Command/CreateNotifyTokenCommand.php
+++ b/Command/CreateNotifyTokenCommand.php
@@ -19,6 +19,7 @@ class CreateNotifyTokenCommand extends ContainerAwareCommand
     protected function configure()
     {
         $this
+            ->setName(static::$defaultName)
             ->addArgument('gateway-name', InputArgument::REQUIRED, 'The gateway name associated with the token')
             ->addOption('model-class', null, InputOption::VALUE_OPTIONAL, 'The model class associated with the token')
             ->addOption('model-id', null, InputOption::VALUE_OPTIONAL, 'The model id associated with the token')
@@ -59,4 +60,4 @@ class CreateNotifyTokenCommand extends ContainerAwareCommand
     {
         return $this->getContainer()->get('payum');
     }
-} 
+}

--- a/Command/DebugGatewayCommand.php
+++ b/Command/DebugGatewayCommand.php
@@ -22,6 +22,7 @@ class DebugGatewayCommand extends ContainerAwareCommand
     protected function configure()
     {
         $this
+            ->setName(static::$defaultName)
             ->setAliases(array(
                 'payum:gateway:debug',
             ))

--- a/Command/StatusCommand.php
+++ b/Command/StatusCommand.php
@@ -20,6 +20,7 @@ class StatusCommand extends ContainerAwareCommand
     protected function configure()
     {
         $this
+            ->setName(static::$defaultName)
             ->setDescription('Allows to get a payment status.')
             ->addArgument('gateway-name', InputArgument::REQUIRED, 'The gateway name')
             ->addOption('model-class', null, InputOption::VALUE_REQUIRED, 'The model class')


### PR DESCRIPTION
Getting the following error only with Symfony 3.3 (3.4 works fine):

```
[Symfony\Component\Console\Exception\LogicException]
  The command defined in "Payum\Bundle\PayumBundle\Command\CreateCaptureToken
  Command" cannot have an empty name.
```