### PR TITLE
Enhance conditional mapping loading (regression introduced in #445)

### DIFF
--- a/DependencyInjection/PayumExtension.php
+++ b/DependencyInjection/PayumExtension.php
@@ -62,7 +62,7 @@ class PayumExtension extends Extension implements PrependExtensionInterface
 
         $this->loadCoreGateway(isset($config['gateways']['core']) ? $config['gateways']['core'] : [], $container);
         unset($config['gateways']['core']);
-        
+
         $this->loadGateways($config['gateways'], $container);
 
         if (isset($config['dynamic_gateways'])) {
@@ -78,27 +78,25 @@ class PayumExtension extends Extension implements PrependExtensionInterface
         $bundles = $container->getParameter('kernel.bundles');
 
         if (isset($bundles['DoctrineBundle'])) {
-            foreach ($container->getExtensionConfig('doctrine') as $config) {
-                // do not register mappings if dbal not configured.
-                if (false == empty($config['dbal']) && false == empty($config['orm'])) {
-                    $rc = new \ReflectionClass(Gateway::class);
-                    $payumRootDir = dirname($rc->getFileName());
+            $config = array_merge(...$container->getExtensionConfig('doctrine'));
 
-                    $container->prependExtensionConfig('doctrine', array(
-                        'orm' => array(
-                            'mappings' => array(
-                                'payum' => array(
-                                    'is_bundle' => false,
-                                    'type' => 'xml',
-                                    'dir' => $payumRootDir.'/Bridge/Doctrine/Resources/mapping',
-                                    'prefix' => 'Payum\Core\Model',
-                                ),
+            // do not register mappings if dbal not configured.
+            if (!empty($config['dbal']) && !empty($config['orm'])) {
+                $rc = new \ReflectionClass(Gateway::class);
+                $payumRootDir = dirname($rc->getFileName());
+
+                $container->prependExtensionConfig('doctrine', array(
+                    'orm' => array(
+                        'mappings' => array(
+                            'payum' => array(
+                                'is_bundle' => false,
+                                'type' => 'xml',
+                                'dir' => $payumRootDir.'/Bridge/Doctrine/Resources/mapping',
+                                'prefix' => 'Payum\Core\Model',
                             ),
                         ),
-                    ));
-
-                    break;
-                }
+                    ),
+                ));
             }
         }
     }
@@ -123,7 +121,7 @@ class PayumExtension extends Extension implements PrependExtensionInterface
     protected function loadCoreGateway(array $config, ContainerBuilder $container)
     {
         $builder = $container->getDefinition('payum.builder');
-        
+
         $defaultConfig = [
             'payum.template.layout' => '@PayumCore\layout.html.twig',
             'payum.template.obtain_credit_card' => '@PayumSymfonyBridge\obtainCreditCard.html.twig',
@@ -134,7 +132,7 @@ class PayumExtension extends Extension implements PrependExtensionInterface
             'payum.action.get_http_request' => new Reference('payum.action.get_http_request'),
             'payum.action.obtain_credit_card' => new Reference('payum.action.obtain_credit_card_builder'),
         ];
-        
+
         $config = array_replace_recursive($defaultConfig, $config);
 
         $builder->addMethodCall('addCoreGatewayFactoryConfig', [$config]);
@@ -289,7 +287,7 @@ class PayumExtension extends Extension implements PrependExtensionInterface
         if (array_key_exists($factoryName, $this->storagesFactories)) {
             throw new InvalidArgumentException(sprintf('The storage factory with such name %s already registered', $factoryName));
         }
-        
+
         $this->storagesFactories[$factoryName] = $factory;
     }
 

--- a/Tests/DependencyInjection/PayumExtensionTest.php
+++ b/Tests/DependencyInjection/PayumExtensionTest.php
@@ -207,7 +207,6 @@ class PayumExtensionTest extends  \PHPUnit_Framework_TestCase
         $container = new ContainerBuilder;
         $container->setParameter('kernel.bundles', array('DoctrineBundle' => 'DoctrineBundle'));
 
-        $container->prependExtensionConfig('doctrine', array());
         $container->prependExtensionConfig('doctrine', array(
             'dbal' => 'not empty',
         ));

--- a/Tests/DependencyInjection/PayumExtensionTest.php
+++ b/Tests/DependencyInjection/PayumExtensionTest.php
@@ -120,22 +120,52 @@ class PayumExtensionTest extends  \PHPUnit_Framework_TestCase
         $container = new ContainerBuilder;
         $container->setParameter('kernel.bundles', array('DoctrineBundle' => 'DoctrineBundle'));
 
+        $container->prependExtensionConfig('doctrine', array(
+            'orm' => 'not empty',
+        ));
+
         $extension->prepend($container);
 
-        $this->assertEquals(array(), $container->getExtensionConfig('doctrine'));
+        $this->assertEquals(array(
+            array(
+                'orm' => 'not empty',
+            )
+        ), $container->getExtensionConfig('doctrine'));
     }
 
     /**
      * @test
      */
-    public function shouldAddPayumMappingIfDoctrineBundleRegisteredAndDbalConfigured()
+    public function shouldNotAddPayumMappingIfDoctrineBundleRegisteredButOrmNotConfigured()
     {
         $extension = new PayumExtension;
 
         $container = new ContainerBuilder;
         $container->setParameter('kernel.bundles', array('DoctrineBundle' => 'DoctrineBundle'));
 
-        $container->prependExtensionConfig('doctrine', array());
+        $container->prependExtensionConfig('doctrine', array(
+            'dbal' => 'not empty',
+        ));
+
+        $extension->prepend($container);
+
+        $this->assertEquals(array(
+            array(
+                'dbal' => 'not empty',
+            )
+        ), $container->getExtensionConfig('doctrine'));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldAddPayumMappingIfDoctrineBundleRegisteredWithDbalAndOrmConfiguredInSingleConfiguration()
+    {
+        $extension = new PayumExtension;
+
+        $container = new ContainerBuilder;
+        $container->setParameter('kernel.bundles', array('DoctrineBundle' => 'DoctrineBundle'));
+
         $container->prependExtensionConfig('doctrine', array(
             'dbal' => 'not empty',
             'orm' => 'not empty'
@@ -162,7 +192,52 @@ class PayumExtensionTest extends  \PHPUnit_Framework_TestCase
                     'dbal' => 'not empty',
                     'orm' => 'not empty'
                 ),
-                array(),
+            ),
+            $container->getExtensionConfig('doctrine')
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function shouldAddPayumMappingIfDoctrineBundleRegisteredWithDbalAndOrmConfiguredInMultipleConfigurations()
+    {
+        $extension = new PayumExtension;
+
+        $container = new ContainerBuilder;
+        $container->setParameter('kernel.bundles', array('DoctrineBundle' => 'DoctrineBundle'));
+
+        $container->prependExtensionConfig('doctrine', array());
+        $container->prependExtensionConfig('doctrine', array(
+            'dbal' => 'not empty',
+        ));
+        $container->prependExtensionConfig('doctrine', array(
+            'orm' => 'not empty',
+        ));
+
+        $extension->prepend($container);
+
+        $rc = new \ReflectionClass('Payum\Core\Gateway');
+        $payumRootDir = dirname($rc->getFileName());
+
+        $this->assertEquals(
+            array(
+                array(
+                    'orm' => array('mappings' => array(
+                        'payum' => array(
+                            'is_bundle' => false,
+                            'type' => 'xml',
+                            'dir' => $payumRootDir.'/Bridge/Doctrine/Resources/mapping',
+                            'prefix' => 'Payum\Core\Model',
+                        )
+                    )),
+                ),
+                array(
+                    'orm' => 'not empty'
+                ),
+                array(
+                    'dbal' => 'not empty',
+                ),
             ),
             $container->getExtensionConfig('doctrine')
         );


### PR DESCRIPTION
It fixes the regression I've mentioned in #445 (basically having doctrine config in two files, one with orm data, another one with dbal data) and it's the last PR to ensure seamless upgrade to the upcoming version for Sylius.