### PR TITLE
Use allowCustomResponseCode instead X-Status-Code

### DIFF
--- a/EventListener/ReplyToHttpResponseListener.php
+++ b/EventListener/ReplyToHttpResponseListener.php
@@ -30,8 +30,14 @@ class ReplyToHttpResponseListener
         }
 
         $response = $this->replyToSymfonyResponseConverter->convert($event->getException());
-        if (false == $response->headers->has('X-Status-Code')) {
-            $response->headers->set('X-Status-Code', $response->getStatusCode());
+        
+        // BC for SF < 3.3
+        if (!method_exists($event, 'allowCustomResponseCode')) {
+            if (false === $response->headers->has('X-Status-Code')) {
+                $response->headers->set('X-Status-Code', $response->getStatusCode());
+            }
+        } else {
+            $event->allowCustomResponseCode();
         }
 
         $event->setResponse($response);


### PR DESCRIPTION
Currently code not work with SF 4.0
X-Status-Code is deprecated from SF 3.3 and is removed in 4.0 -https://github.com/symfony/symfony/pull/19822/files