### PR TITLE
Allow sessionTokenAction to POST redirect

### DIFF
--- a/Controller/CaptureController.php
+++ b/Controller/CaptureController.php
@@ -1,6 +1,7 @@
 <?php
 namespace Payum\Bundle\PayumBundle\Controller;
 
+use Payum\Core\Reply\HttpPostRedirect;
 use Payum\Core\Request\Capture;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -19,12 +20,18 @@ class CaptureController extends PayumController
 
         $request->getSession()->remove('payum_token');
 
-        return $this->redirect($this->generateUrl('payum_capture_do', array_replace(
+        $redirectUrl = $this->generateUrl('payum_capture_do', array_replace(
             $request->query->all(),
             array(
                 'payum_token' => $hash,
             )
-        )));
+        ));
+
+        if ($request->isMethod('POST')) {
+            throw new HttpPostRedirect($redirectUrl, $request->request->all());
+        }
+
+        return $this->redirect($redirectUrl);
     }
 
     public function doAction(Request $request)


### PR DESCRIPTION
I am currently implementing a PSP (2C2P) that needs a POST redirect from the session capture action.
Currently the session capture action only redirects via GET.
This PR adds the ability to forward a POST request, depending on the incoming request method.