### PR TITLE
Use FQCN::method notation

### DIFF
--- a/Resources/config/routing/authorize.xml
+++ b/Resources/config/routing/authorize.xml
@@ -2,6 +2,6 @@
 
 <routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
     <route id="payum_authorize_do" path="/payment/authorize/{payum_token}">
-        <default key="_controller">PayumBundle:Authorize:do</default>
+        <default key="_controller">Payum\Bundle\PayumBundle\Controller\AuthorizeController::doAction</default>
     </route>
 </routes>

--- a/Resources/config/routing/cancel.xml
+++ b/Resources/config/routing/cancel.xml
@@ -2,6 +2,6 @@
 
 <routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
     <route id="payum_cancel_do" path="/payment/cancel/{payum_token}">
-        <default key="_controller">PayumBundle:Cancel:do</default>
+        <default key="_controller">Payum\Bundle\PayumBundle\Controller\CancelController::doAction</default>
     </route>
 </routes>

--- a/Resources/config/routing/capture.xml
+++ b/Resources/config/routing/capture.xml
@@ -2,10 +2,10 @@
 
 <routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
     <route id="payum_capture_do_session" path="/payment/capture/session-token">
-        <default key="_controller">PayumBundle:Capture:doSessionToken</default>
+        <default key="_controller">Payum\Bundle\PayumBundle\Controller\CaptureController::doSessionTokenAction</default>
     </route>
 
     <route id="payum_capture_do" path="/payment/capture/{payum_token}">
-        <default key="_controller">PayumBundle:Capture:do</default>
+        <default key="_controller">Payum\Bundle\PayumBundle\Controller\CaptureController::doAction</default>
     </route>
 </routes>

--- a/Resources/config/routing/notify.xml
+++ b/Resources/config/routing/notify.xml
@@ -2,10 +2,10 @@
 
 <routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
     <route id="payum_notify_do_unsafe" path="/payment/notify/unsafe/{gateway}">
-        <default key="_controller">PayumBundle:Notify:doUnsafe</default>
+        <default key="_controller">Payum\Bundle\PayumBundle\Controller\NotifyController::doUnsafeAction</default>
     </route>
 
     <route id="payum_notify_do" path="/payment/notify/{payum_token}">
-        <default key="_controller">PayumBundle:Notify:do</default>
+        <default key="_controller">Payum\Bundle\PayumBundle\Controller\NotifyController::doAction</default>
     </route>
 </routes>

--- a/Resources/config/routing/payout.xml
+++ b/Resources/config/routing/payout.xml
@@ -2,6 +2,6 @@
 
 <routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
     <route id="payum_payout_do" path="/payment/payout/{payum_token}">
-        <default key="_controller">PayumBundle:Payout:do</default>
+        <default key="_controller">Payum\Bundle\PayumBundle\Controller\PayoutController::doAction</default>
     </route>
 </routes>

--- a/Resources/config/routing/refund.xml
+++ b/Resources/config/routing/refund.xml
@@ -2,6 +2,6 @@
 
 <routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
     <route id="payum_refund_do" path="/payment/refund/{payum_token}">
-        <default key="_controller">PayumBundle:Refund:do</default>
+        <default key="_controller">Payum\Bundle\PayumBundle\Controller\RefundController::doAction</default>
     </route>
 </routes>

--- a/Resources/config/routing/sync.xml
+++ b/Resources/config/routing/sync.xml
@@ -2,6 +2,6 @@
 
 <routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
     <route id="payum_sync_do" path="/payment/sync/{payum_token}">
-        <default key="_controller">PayumBundle:Sync:do</default>
+        <default key="_controller">Payum\Bundle\PayumBundle\Controller\SyncController::doAction</default>
     </route>
 </routes>


### PR DESCRIPTION
Fixes #490. From what I've checked the `FQCN::method` notation should work in Symfony 3.1 as long as we stick with setting `_controller` key (i.e. not using `controller` attribute which is not present in 3.x docs)