### PR TITLE
Require a HTTP Client as Payum/Core requires a http client implementation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,7 @@
         "doctrine/orm": "~2.5",
         "payum/payum": "^1.5@dev",
         "payum/omnipay-v3-bridge": "^1@alpha",
+        "symfony/http-client": "^4.4|^5",
 
         "php-http/guzzle6-adapter": "^1",
         "omnipay/dummy": "^3@alpha",


### PR DESCRIPTION
This requirement is required to avoid a dependency error when we use
Symfony flex recipes.

See <https://travis-ci.org/symfony/recipes-contrib/jobs/655281894>.

I prefer to put this new requirement in the bundle since I force the http client to be the symfony one.

#### Update

I think a `require-dev` is better than a `require` since it doesn't force the developer to use the symfony implementation of the http-client.  
