### PR TITLE
Fixed compliance with psr-4 autoloading standard for test classes

### DIFF
--- a/Tests/DependencyInjection/Compiler/BuildConfigsPassTest.php
+++ b/Tests/DependencyInjection/Compiler/BuildConfigsPassTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Payum\Bundle\PayumBundle\Tests\DependencyInjection\Factory\Compiler;
+namespace Payum\Bundle\PayumBundle\Tests\DependencyInjection\Compiler;
 
 use Payum\Bundle\PayumBundle\DependencyInjection\Compiler\BuildConfigsPass;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;

--- a/Tests/DependencyInjection/Compiler/BuildGatewayFactoriesBuilderPassTest.php
+++ b/Tests/DependencyInjection/Compiler/BuildGatewayFactoriesBuilderPassTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Payum\Bundle\PayumBundle\Tests\DependencyInjection\Factory\Compiler;
+namespace Payum\Bundle\PayumBundle\Tests\DependencyInjection\Compiler;
 
 use Payum\Bundle\PayumBundle\DependencyInjection\Compiler\BuildConfigsPass;
 use Payum\Bundle\PayumBundle\DependencyInjection\Compiler\BuildGatewayFactoriesBuilderPass;

--- a/Tests/DependencyInjection/Compiler/BuildGatewayFactoriesPassTest.php
+++ b/Tests/DependencyInjection/Compiler/BuildGatewayFactoriesPassTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Payum\Bundle\PayumBundle\Tests\DependencyInjection\Factory\Compiler;
+namespace Payum\Bundle\PayumBundle\Tests\DependencyInjection\Compiler;
 
 use Payum\Bundle\PayumBundle\DependencyInjection\Compiler\BuildConfigsPass;
 use Payum\Bundle\PayumBundle\DependencyInjection\Compiler\BuildGatewayFactoriesPass;

--- a/Tests/DependencyInjection/Compiler/BuildGatewaysPassTest.php
+++ b/Tests/DependencyInjection/Compiler/BuildGatewaysPassTest.php
@@ -1,8 +1,6 @@
 <?php
-namespace Payum\Bundle\PayumBundle\Tests\DependencyInjection\Factory\Compiler;
+namespace Payum\Bundle\PayumBundle\Tests\DependencyInjection\Compiler;
 
-use Payum\Bundle\PayumBundle\DependencyInjection\Compiler\BuildConfigsPass;
-use Payum\Bundle\PayumBundle\DependencyInjection\Compiler\BuildGatewayFactoriesPass;
 use Payum\Bundle\PayumBundle\DependencyInjection\Compiler\BuildGatewaysPass;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;

--- a/Tests/DependencyInjection/Compiler/BuildStoragesPassTest.php
+++ b/Tests/DependencyInjection/Compiler/BuildStoragesPassTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Payum\Bundle\PayumBundle\Tests\DependencyInjection\Factory\Compiler;
+namespace Payum\Bundle\PayumBundle\Tests\DependencyInjection\Compiler;
 
 use Payum\Bundle\PayumBundle\DependencyInjection\Compiler\BuildConfigsPass;
 use Payum\Bundle\PayumBundle\DependencyInjection\Compiler\BuildGatewayFactoriesPass;

--- a/Tests/DependencyInjection/Factory/AbstractStorageFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/AbstractStorageFactoryTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Payum\Bundle\PayumBundle\Tests\DependencyInjection\Factory\Storage;
+namespace Payum\Bundle\PayumBundle\Tests\DependencyInjection\Factory;
 
 use Payum\Bundle\PayumBundle\DependencyInjection\Factory\Storage\AbstractStorageFactory;
 use Payum\Bundle\PayumBundle\DependencyInjection\Factory\Storage\StorageFactoryInterface;

--- a/Tests/DependencyInjection/Factory/CustomStorageFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/CustomStorageFactoryTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Payum\Bundle\PayumBundle\Tests\DependencyInjection\Factory\Storage;
+namespace Payum\Bundle\PayumBundle\Tests\DependencyInjection\Factory;
 
 
 use Payum\Bundle\PayumBundle\DependencyInjection\Factory\Storage\CustomStorageFactory;

--- a/Tests/DependencyInjection/Factory/DoctrineStorageFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/DoctrineStorageFactoryTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Payum\Bundle\PayumBundle\Tests\DependencyInjection\Factory\Storage;
+namespace Payum\Bundle\PayumBundle\Tests\DependencyInjection\Factory;
 
 use Payum\Bundle\PayumBundle\DependencyInjection\Factory\Storage\DoctrineStorageFactory;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;

--- a/Tests/DependencyInjection/Factory/FilesystemStorageFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/FilesystemStorageFactoryTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Payum\Bundle\PayumBundle\Tests\DependencyInjection\Factory\Storage;
+namespace Payum\Bundle\PayumBundle\Tests\DependencyInjection\Factory;
 
 use Payum\Bundle\PayumBundle\DependencyInjection\Factory\Storage\FilesystemStorageFactory;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;

--- a/Tests/DependencyInjection/Factory/Propel1StorageFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Propel1StorageFactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Payum\Bundle\PayumBundle\Tests\DependencyInjection\Factory\Storage;
+namespace Payum\Bundle\PayumBundle\Tests\DependencyInjection\Factory;
 
 use Payum\Bundle\PayumBundle\DependencyInjection\Factory\Storage\Propel1StorageFactory;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;

--- a/Tests/DependencyInjection/Factory/Propel2StorageFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Propel2StorageFactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Payum\Bundle\PayumBundle\Tests\DependencyInjection\Factory\Storage;
+namespace Payum\Bundle\PayumBundle\Tests\DependencyInjection\Factory;
 
 use Payum\Bundle\PayumBundle\DependencyInjection\Factory\Storage\Propel2StorageFactory;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;

--- a/Tests/Sonata/GatewayConfigAdminTest.php
+++ b/Tests/Sonata/GatewayConfigAdminTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Payum\Bundle\PayumBundle\Sonata\Tests;
+namespace Payum\Bundle\PayumBundle\Tests\Sonata;
 
 use Payum\Bundle\PayumBundle\Sonata\GatewayConfigAdmin;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
Without compliance with psr-4, it will not autoload anymore in Composer v2.0. It currently displays a warning message with composer ^1.10.

Maybe consider not exporting the tests files.
` /Tests            export-ignore `
