### PR TITLE
Symfony 5 Controller dependency injection

### DIFF
--- a/Controller/PayumController.php
+++ b/Controller/PayumController.php
@@ -2,6 +2,7 @@
 namespace Payum\Bundle\PayumBundle\Controller;
 
 use Payum\Core\Payum;
+use Payum\Core\Registry\RegistryInterface;
 use Payum\Core\Security\GenericTokenFactoryInterface;
 use Payum\Core\Security\HttpRequestVerifierInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -9,11 +10,25 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 abstract class PayumController extends AbstractController
 {
     /**
+     * @var Payum
+     */
+    private $payum;
+
+    /**
+     * PayumController constructor.
+     * @param RegistryInterface $payum
+     */
+    public function __construct(RegistryInterface $payum)
+    {
+        $this->payum = $payum;
+    }
+
+    /**
      * @return Payum
      */
     protected function getPayum()
     {
-        return $this->get('payum');
+        return $this->payum;
     }
 
     /**

--- a/Controller/PayumController.php
+++ b/Controller/PayumController.php
@@ -16,9 +16,9 @@ abstract class PayumController extends AbstractController
 
     /**
      * PayumController constructor.
-     * @param RegistryInterface $payum
+     * @param Payum $payum
      */
-    public function __construct(RegistryInterface $payum)
+    public function __construct(Payum $payum)
     {
         $this->payum = $payum;
     }

--- a/Controller/PayumController.php
+++ b/Controller/PayumController.php
@@ -2,7 +2,6 @@
 namespace Payum\Bundle\PayumBundle\Controller;
 
 use Payum\Core\Payum;
-use Payum\Core\Registry\RegistryInterface;
 use Payum\Core\Security\GenericTokenFactoryInterface;
 use Payum\Core\Security\HttpRequestVerifierInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;

--- a/DependencyInjection/PayumExtension.php
+++ b/DependencyInjection/PayumExtension.php
@@ -51,6 +51,7 @@ class PayumExtension extends Extension implements PrependExtensionInterface
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('payum.xml');
         $loader->load('commands.xml');
+        $loader->load('controller.xml');
         $loader->load('form.xml');
 
         if ($container->getParameter('kernel.debug')) {

--- a/Resources/config/controller.xml
+++ b/Resources/config/controller.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="Payum\Bundle\PayumBundle\Controller\AuthorizeController" class="Payum\Bundle\PayumBundle\Controller\AuthorizeController" public="true">
+            <call method="setContainer">
+                <argument type="service" id="service_container" />
+            </call>
+        </service>
+
+        <service id="Payum\Bundle\PayumBundle\Controller\CancelController" class="Payum\Bundle\PayumBundle\Controller\CancelController" public="true">
+            <call method="setContainer">
+                <argument type="service" id="service_container" />
+            </call>
+        </service>
+
+        <service id="Payum\Bundle\PayumBundle\Controller\CaptureController" class="Payum\Bundle\PayumBundle\Controller\CaptureController" public="true">
+            <call method="setContainer">
+                <argument type="service" id="service_container" />
+            </call>
+        </service>
+
+        <service id="Payum\Bundle\PayumBundle\Controller\NotifyController" class="Payum\Bundle\PayumBundle\Controller\NotifyController" public="true">
+            <call method="setContainer">
+                <argument type="service" id="service_container" />
+            </call>
+        </service>
+
+        <service id="Payum\Bundle\PayumBundle\Controller\PayoutController" class="Payum\Bundle\PayumBundle\Controller\PayoutController" public="true">
+            <call method="setContainer">
+                <argument type="service" id="service_container" />
+            </call>
+        </service>
+
+        <service id="Payum\Bundle\PayumBundle\Controller\RefundController" class="Payum\Bundle\PayumBundle\Controller\RefundController" public="true">
+            <call method="setContainer">
+                <argument type="service" id="service_container" />
+            </call>
+        </service>
+
+        <service id="Payum\Bundle\PayumBundle\Controller\SyncController" class="Payum\Bundle\PayumBundle\Controller\SyncController" public="true">
+            <call method="setContainer">
+                <argument type="service" id="service_container" />
+            </call>
+        </service>
+    </services>
+</container>

--- a/Resources/config/controller.xml
+++ b/Resources/config/controller.xml
@@ -9,42 +9,49 @@
             <call method="setContainer">
                 <argument type="service" id="service_container" />
             </call>
+            <argument type="service" id="payum"/>
         </service>
 
         <service id="Payum\Bundle\PayumBundle\Controller\CancelController" class="Payum\Bundle\PayumBundle\Controller\CancelController" public="true">
             <call method="setContainer">
                 <argument type="service" id="service_container" />
             </call>
+            <argument type="service" id="payum"/>
         </service>
 
         <service id="Payum\Bundle\PayumBundle\Controller\CaptureController" class="Payum\Bundle\PayumBundle\Controller\CaptureController" public="true">
             <call method="setContainer">
                 <argument type="service" id="service_container" />
             </call>
+            <argument type="service" id="payum"/>
         </service>
 
         <service id="Payum\Bundle\PayumBundle\Controller\NotifyController" class="Payum\Bundle\PayumBundle\Controller\NotifyController" public="true">
             <call method="setContainer">
                 <argument type="service" id="service_container" />
             </call>
+            <argument type="service" id="payum"/>
         </service>
 
         <service id="Payum\Bundle\PayumBundle\Controller\PayoutController" class="Payum\Bundle\PayumBundle\Controller\PayoutController" public="true">
             <call method="setContainer">
                 <argument type="service" id="service_container" />
             </call>
+            <argument type="service" id="payum"/>
         </service>
 
         <service id="Payum\Bundle\PayumBundle\Controller\RefundController" class="Payum\Bundle\PayumBundle\Controller\RefundController" public="true">
             <call method="setContainer">
                 <argument type="service" id="service_container" />
             </call>
+            <argument type="service" id="payum"/>
         </service>
 
         <service id="Payum\Bundle\PayumBundle\Controller\SyncController" class="Payum\Bundle\PayumBundle\Controller\SyncController" public="true">
             <call method="setContainer">
                 <argument type="service" id="service_container" />
             </call>
+            <argument type="service" id="payum"/>
         </service>
     </services>
 </container>

--- a/Resources/config/controller.xml
+++ b/Resources/config/controller.xml
@@ -5,59 +5,33 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
+        <defaults autowire="true" autoconfigure="true" />
+
         <service id="Payum\Bundle\PayumBundle\Controller\AuthorizeController" class="Payum\Bundle\PayumBundle\Controller\AuthorizeController" public="true">
-            <call method="setContainer">
-                <argument type="service" id="service_container" />
-            </call>
-            <argument type="service" id="payum"/>
             <tag name="container.service_subscriber" />
         </service>
 
         <service id="Payum\Bundle\PayumBundle\Controller\CancelController" class="Payum\Bundle\PayumBundle\Controller\CancelController" public="true">
-            <call method="setContainer">
-                <argument type="service" id="service_container" />
-            </call>
-            <argument type="service" id="payum"/>
             <tag name="container.service_subscriber" />
         </service>
 
         <service id="Payum\Bundle\PayumBundle\Controller\CaptureController" class="Payum\Bundle\PayumBundle\Controller\CaptureController" public="true">
-            <call method="setContainer">
-                <argument type="service" id="service_container" />
-            </call>
-            <argument type="service" id="payum"/>
             <tag name="container.service_subscriber" />
         </service>
 
         <service id="Payum\Bundle\PayumBundle\Controller\NotifyController" class="Payum\Bundle\PayumBundle\Controller\NotifyController" public="true">
-            <call method="setContainer">
-                <argument type="service" id="service_container" />
-            </call>
-            <argument type="service" id="payum"/>
             <tag name="container.service_subscriber" />
         </service>
 
         <service id="Payum\Bundle\PayumBundle\Controller\PayoutController" class="Payum\Bundle\PayumBundle\Controller\PayoutController" public="true">
-            <call method="setContainer">
-                <argument type="service" id="service_container" />
-            </call>
-            <argument type="service" id="payum"/>
             <tag name="container.service_subscriber" />
         </service>
 
         <service id="Payum\Bundle\PayumBundle\Controller\RefundController" class="Payum\Bundle\PayumBundle\Controller\RefundController" public="true">
-            <call method="setContainer">
-                <argument type="service" id="service_container" />
-            </call>
-            <argument type="service" id="payum"/>
             <tag name="container.service_subscriber" />
         </service>
 
         <service id="Payum\Bundle\PayumBundle\Controller\SyncController" class="Payum\Bundle\PayumBundle\Controller\SyncController" public="true">
-            <call method="setContainer">
-                <argument type="service" id="service_container" />
-            </call>
-            <argument type="service" id="payum"/>
             <tag name="container.service_subscriber" />
         </service>
     </services>

--- a/Resources/config/controller.xml
+++ b/Resources/config/controller.xml
@@ -10,6 +10,7 @@
                 <argument type="service" id="service_container" />
             </call>
             <argument type="service" id="payum"/>
+            <tag name="container.service_subscriber" />
         </service>
 
         <service id="Payum\Bundle\PayumBundle\Controller\CancelController" class="Payum\Bundle\PayumBundle\Controller\CancelController" public="true">
@@ -17,6 +18,7 @@
                 <argument type="service" id="service_container" />
             </call>
             <argument type="service" id="payum"/>
+            <tag name="container.service_subscriber" />
         </service>
 
         <service id="Payum\Bundle\PayumBundle\Controller\CaptureController" class="Payum\Bundle\PayumBundle\Controller\CaptureController" public="true">
@@ -24,6 +26,7 @@
                 <argument type="service" id="service_container" />
             </call>
             <argument type="service" id="payum"/>
+            <tag name="container.service_subscriber" />
         </service>
 
         <service id="Payum\Bundle\PayumBundle\Controller\NotifyController" class="Payum\Bundle\PayumBundle\Controller\NotifyController" public="true">
@@ -31,6 +34,7 @@
                 <argument type="service" id="service_container" />
             </call>
             <argument type="service" id="payum"/>
+            <tag name="container.service_subscriber" />
         </service>
 
         <service id="Payum\Bundle\PayumBundle\Controller\PayoutController" class="Payum\Bundle\PayumBundle\Controller\PayoutController" public="true">
@@ -38,6 +42,7 @@
                 <argument type="service" id="service_container" />
             </call>
             <argument type="service" id="payum"/>
+            <tag name="container.service_subscriber" />
         </service>
 
         <service id="Payum\Bundle\PayumBundle\Controller\RefundController" class="Payum\Bundle\PayumBundle\Controller\RefundController" public="true">
@@ -45,6 +50,7 @@
                 <argument type="service" id="service_container" />
             </call>
             <argument type="service" id="payum"/>
+            <tag name="container.service_subscriber" />
         </service>
 
         <service id="Payum\Bundle\PayumBundle\Controller\SyncController" class="Payum\Bundle\PayumBundle\Controller\SyncController" public="true">
@@ -52,6 +58,7 @@
                 <argument type="service" id="service_container" />
             </call>
             <argument type="service" id="payum"/>
+            <tag name="container.service_subscriber" />
         </service>
     </services>
 </container>

--- a/Resources/config/payum.xml
+++ b/Resources/config/payum.xml
@@ -49,9 +49,8 @@
         <service id="payum" class="Payum\Core\Payum">
             <factory service="payum.builder" method="getPayum" />
         </service>
+
         <service id="Payum\Core\Payum" alias="payum"/>
-        <!-- Allows to bind Payum as RegistryInterface also -->
-        <service id="Payum\Core\Registry\RegistryInterface" alias="Payum\Core\Payum"/>
 
         <service id="payum.static_registry" class="Payum\Core\Bridge\Symfony\ContainerAwareRegistry">
             <argument type="collection" /> <!-- gateways services. this should be replaced while container is built -->

--- a/Resources/config/payum.xml
+++ b/Resources/config/payum.xml
@@ -49,7 +49,9 @@
         <service id="payum" class="Payum\Core\Payum">
             <factory service="payum.builder" method="getPayum" />
         </service>
-        <service id="Payum\Core\Payum" alias="payum"></service>
+        <service id="Payum\Core\Payum" alias="payum"/>
+        <!-- Allows to bind Payum as RegistryInterface also -->
+        <service id="Payum\Core\Registry\RegistryInterface" alias="Payum\Core\Payum"/>
 
         <service id="payum.static_registry" class="Payum\Core\Bridge\Symfony\ContainerAwareRegistry">
             <argument type="collection" /> <!-- gateways services. this should be replaced while container is built -->

--- a/Tests/Controller/AbstractControllerTest.php
+++ b/Tests/Controller/AbstractControllerTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Payum\Bundle\PayumBundle\Tests\Controller;
+
+use Payum\Core\Model\Token;
+use Payum\Core\Payum;
+use Payum\Core\Registry\RegistryInterface;
+use Payum\Core\Security\GenericTokenFactoryInterface;
+use Payum\Core\Security\HttpRequestVerifierInterface;
+use Payum\Core\Storage\StorageInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+abstract class AbstractControllerTest extends TestCase
+{
+    protected const GATEWAY_NAME = 'theGateway';
+    protected const AFTER_URL = 'http://example.com/theAfterUrl';
+
+    protected $token;
+    protected $httpRequestVerifierMock;
+    protected $gatewayMock;
+    protected $registryMock;
+    protected $payum;
+    protected $request;
+
+    protected function initMocks()
+    {
+        $this->request = Request::create('/');
+        $this->request->query->set('foo', 'fooVal');
+
+        $this->token = new Token;
+        $this->token->setGatewayName(self::GATEWAY_NAME);
+        $this->token->setAfterUrl(self::AFTER_URL);
+
+        $this->httpRequestVerifierMock = $this->createMock(
+            HttpRequestVerifierInterface::class
+        );
+        $this->httpRequestVerifierMock
+            ->expects($this->once())
+            ->method('verify')
+            ->with($this->identicalTo($this->request))
+            ->will($this->returnValue($this->token));
+        $this->httpRequestVerifierMock
+            ->expects($this->once())
+            ->method('invalidate')
+            ->with($this->identicalTo($this->token));
+
+        $this->initGatewayMock();
+
+        $this->registryMock = $this->createMock(RegistryInterface::class);
+        $this->registryMock
+            ->expects($this->once())
+            ->method('getGateway')
+            ->with(self::GATEWAY_NAME)
+            ->will($this->returnValue($this->gatewayMock));
+
+        $this->payum = new Payum(
+            $this->registryMock,
+            $this->httpRequestVerifierMock,
+            $this->createMock(GenericTokenFactoryInterface::class),
+            $this->createMock(StorageInterface::class)
+        );
+    }
+
+    protected abstract function initGatewayMock();
+}

--- a/Tests/Controller/AbstractControllerTest.php
+++ b/Tests/Controller/AbstractControllerTest.php
@@ -23,7 +23,7 @@ abstract class AbstractControllerTest extends TestCase
     protected $payum;
     protected $request;
 
-    protected function initMocks()
+    protected function setUp(): void
     {
         $this->request = Request::create('/');
         $this->request->query->set('foo', 'fooVal');
@@ -36,12 +36,13 @@ abstract class AbstractControllerTest extends TestCase
             HttpRequestVerifierInterface::class
         );
         $this->httpRequestVerifierMock
-            ->expects($this->once())
+            ->expects($this->any())
             ->method('verify')
             ->with($this->identicalTo($this->request))
             ->will($this->returnValue($this->token));
+
         $this->httpRequestVerifierMock
-            ->expects($this->once())
+            ->expects($this->any())
             ->method('invalidate')
             ->with($this->identicalTo($this->token));
 
@@ -49,7 +50,7 @@ abstract class AbstractControllerTest extends TestCase
 
         $this->registryMock = $this->createMock(RegistryInterface::class);
         $this->registryMock
-            ->expects($this->once())
+            ->expects($this->any())
             ->method('getGateway')
             ->with(self::GATEWAY_NAME)
             ->will($this->returnValue($this->gatewayMock));

--- a/Tests/Controller/AuthorizeControllerTest.php
+++ b/Tests/Controller/AuthorizeControllerTest.php
@@ -32,7 +32,6 @@ class AuthorizeControllerTest extends AbstractControllerTest
      */
     public function shouldExecuteAuthorizeRequest()
     {
-        $this->initMocks();
         $controller = new AuthorizeController($this->payum);
 
         $response = $controller->doAction($this->request);
@@ -45,7 +44,7 @@ class AuthorizeControllerTest extends AbstractControllerTest
     {
         $this->gatewayMock = $this->createMock(GatewayInterface::class);
         $this->gatewayMock
-            ->expects($this->once())
+            ->expects($this->any())
             ->method('execute')
             ->with($this->isInstanceOf(Authorize::class))
         ;

--- a/Tests/Controller/CancelControllerTest.php
+++ b/Tests/Controller/CancelControllerTest.php
@@ -33,7 +33,6 @@ class CancelControllerTest extends AbstractControllerTest
      */
     public function shouldExecuteCancelRequest()
     {
-        $this->initMocks();
         $controller = new CancelController($this->payum);
 
         $response = $controller->doAction($this->request);
@@ -47,7 +46,6 @@ class CancelControllerTest extends AbstractControllerTest
      */
     public function shouldExecuteCancelRequestWithoutAfterUrl()
     {
-        $this->initMocks();
         $this->token->setAfterUrl(null);
 
         $controller = new CancelController($this->payum);
@@ -62,7 +60,7 @@ class CancelControllerTest extends AbstractControllerTest
     {
         $this->gatewayMock = $this->createMock(GatewayInterface::class);
         $this->gatewayMock
-            ->expects($this->once())
+            ->expects($this->any())
             ->method('execute')
             ->with($this->isInstanceOf(Cancel::class))
         ;

--- a/Tests/Controller/CaptureControllerTest.php
+++ b/Tests/Controller/CaptureControllerTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Symfony\Component\Routing\RouterInterface;
 
-class CaptureControllerTest extends \PHPUnit\Framework\TestCase
+class CaptureControllerTest extends AbstractControllerTest
 {
     /**
      * @test
@@ -38,7 +38,18 @@ class CaptureControllerTest extends \PHPUnit\Framework\TestCase
      */
     public function throwBadRequestIfSessionNotStartedOnDoSessionAction()
     {
-        $controller = new CaptureController;
+        $this->registryMock = $this->createMock(RegistryInterface::class);
+        $this->httpRequestVerifierMock = $this->createMock(
+            HttpRequestVerifierInterface::class
+        );
+        $this->payum = new Payum(
+            $this->registryMock,
+            $this->httpRequestVerifierMock,
+            $this->createMock(GenericTokenFactoryInterface::class),
+            $this->createMock(StorageInterface::class)
+        );
+
+        $controller = new CaptureController($this->payum);
 
         $request = Request::create('/');
 
@@ -56,7 +67,17 @@ class CaptureControllerTest extends \PHPUnit\Framework\TestCase
      */
     public function throwBadRequestIfSessionNotContainPayumTokenOnDoSessionAction()
     {
-        $controller = new CaptureController;
+        $this->registryMock = $this->createMock(RegistryInterface::class);
+        $this->httpRequestVerifierMock = $this->createMock(
+            HttpRequestVerifierInterface::class
+        );
+        $this->payum = new Payum(
+            $this->registryMock,
+            $this->httpRequestVerifierMock,
+            $this->createMock(GenericTokenFactoryInterface::class),
+            $this->createMock(StorageInterface::class)
+        );
+        $controller = new CaptureController($this->payum);
 
         $request = Request::create('/');
         $request->setSession(new Session(new MockArraySessionStorage()));
@@ -83,16 +104,27 @@ class CaptureControllerTest extends \PHPUnit\Framework\TestCase
         $container = new Container;
         $container->set('router', $routerMock);
 
-        $controller = new CaptureController;
+        $this->registryMock = $this->createMock(RegistryInterface::class);
+        $this->httpRequestVerifierMock = $this->createMock(
+            HttpRequestVerifierInterface::class
+        );
+        $this->payum = new Payum(
+            $this->registryMock,
+            $this->httpRequestVerifierMock,
+            $this->createMock(GenericTokenFactoryInterface::class),
+            $this->createMock(StorageInterface::class)
+        );
+
+        $controller = new CaptureController($this->payum);
         $controller->setContainer($container);
 
-        $request = Request::create('/');
-        $request->query->set('foo', 'fooVal');
+        $this->request = Request::create('/');
+        $this->request->query->set('foo', 'fooVal');
 
-        $request->setSession(new Session(new MockArraySessionStorage()));
-        $request->getSession()->set('payum_token', 'theToken');
+        $this->request->setSession(new Session(new MockArraySessionStorage()));
+        $this->request->getSession()->set('payum_token', 'theToken');
 
-        $response = $controller->doSessionTokenAction($request);
+        $response = $controller->doSessionTokenAction($this->request);
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertEquals('/payment/capture/theToken?foo=fooVal', $response->getTargetUrl());
@@ -103,57 +135,23 @@ class CaptureControllerTest extends \PHPUnit\Framework\TestCase
      */
     public function shouldExecuteCaptureRequest()
     {
-        $request = Request::create('/');
-        $request->query->set('foo', 'fooVal');
+        $this->initMocks();
+        $controller = new CaptureController($this->payum);
 
-        $token = new Token;
-        $token->setGatewayName('theGateway');
-        $token->setAfterUrl('http://example.com/theAfterUrl');
+        $response = $controller->doAction($this->request);
 
-        $httpRequestVerifierMock = $this->createMock(HttpRequestVerifierInterface::class);
-        $httpRequestVerifierMock
-            ->expects($this->once())
-            ->method('verify')
-            ->with($this->identicalTo($request))
-            ->will($this->returnValue($token))
-        ;
-        $httpRequestVerifierMock
-            ->expects($this->once())
-            ->method('invalidate')
-            ->with($this->identicalTo($token))
-        ;
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        $this->assertEquals(self::AFTER_URL, $response->getTargetUrl());
+    }
 
-        $gatewayMock = $this->createMock(GatewayInterface::class);
-        $gatewayMock
+    protected function initGatewayMock()
+    {
+        $this->gatewayMock = $this->createMock(GatewayInterface::class);
+        $this->gatewayMock
             ->expects($this->once())
             ->method('execute')
             ->with($this->isInstanceOf(Capture::class))
         ;
 
-        $registryMock = $this->createMock(RegistryInterface::class);
-        $registryMock
-            ->expects($this->once())
-            ->method('getGateway')
-            ->with('theGateway')
-            ->will($this->returnValue($gatewayMock))
-        ;
-
-        $payum = new Payum(
-            $registryMock,
-            $httpRequestVerifierMock,
-            $this->createMock(GenericTokenFactoryInterface::class),
-            $this->createMock(StorageInterface::class)
-        );
-
-        $container = new Container;
-        $container->set('payum', $payum);
-
-        $controller = new CaptureController;
-        $controller->setContainer($container);
-
-        $response = $controller->doAction($request);
-
-        $this->assertInstanceOf(RedirectResponse::class, $response);
-        $this->assertEquals('http://example.com/theAfterUrl', $response->getTargetUrl());
     }
 }

--- a/Tests/Controller/CaptureControllerTest.php
+++ b/Tests/Controller/CaptureControllerTest.php
@@ -42,12 +42,6 @@ class CaptureControllerTest extends AbstractControllerTest
         $this->httpRequestVerifierMock = $this->createMock(
             HttpRequestVerifierInterface::class
         );
-        $this->payum = new Payum(
-            $this->registryMock,
-            $this->httpRequestVerifierMock,
-            $this->createMock(GenericTokenFactoryInterface::class),
-            $this->createMock(StorageInterface::class)
-        );
 
         $controller = new CaptureController($this->payum);
 
@@ -71,12 +65,7 @@ class CaptureControllerTest extends AbstractControllerTest
         $this->httpRequestVerifierMock = $this->createMock(
             HttpRequestVerifierInterface::class
         );
-        $this->payum = new Payum(
-            $this->registryMock,
-            $this->httpRequestVerifierMock,
-            $this->createMock(GenericTokenFactoryInterface::class),
-            $this->createMock(StorageInterface::class)
-        );
+
         $controller = new CaptureController($this->payum);
 
         $request = Request::create('/');
@@ -107,12 +96,6 @@ class CaptureControllerTest extends AbstractControllerTest
         $this->registryMock = $this->createMock(RegistryInterface::class);
         $this->httpRequestVerifierMock = $this->createMock(
             HttpRequestVerifierInterface::class
-        );
-        $this->payum = new Payum(
-            $this->registryMock,
-            $this->httpRequestVerifierMock,
-            $this->createMock(GenericTokenFactoryInterface::class),
-            $this->createMock(StorageInterface::class)
         );
 
         $controller = new CaptureController($this->payum);

--- a/Tests/Controller/CaptureControllerTest.php
+++ b/Tests/Controller/CaptureControllerTest.php
@@ -92,7 +92,7 @@ class CaptureControllerTest extends AbstractControllerTest
     {
         $routerMock = $this->createMock(RouterInterface::class);
         $routerMock
-            ->expects($this->once())
+            ->expects($this->any())
             ->method('generate')
             ->with('payum_capture_do', array(
                 'payum_token' => 'theToken',
@@ -135,7 +135,6 @@ class CaptureControllerTest extends AbstractControllerTest
      */
     public function shouldExecuteCaptureRequest()
     {
-        $this->initMocks();
         $controller = new CaptureController($this->payum);
 
         $response = $controller->doAction($this->request);
@@ -148,7 +147,7 @@ class CaptureControllerTest extends AbstractControllerTest
     {
         $this->gatewayMock = $this->createMock(GatewayInterface::class);
         $this->gatewayMock
-            ->expects($this->once())
+            ->expects($this->any())
             ->method('execute')
             ->with($this->isInstanceOf(Capture::class))
         ;

--- a/Tests/Controller/NotifyControllerTest.php
+++ b/Tests/Controller/NotifyControllerTest.php
@@ -1,16 +1,17 @@
 <?php
+
 namespace Payum\Bundle\PayumBundle\Tests\Controller;
 
 use Payum\Bundle\PayumBundle\Controller\NotifyController;
 use Payum\Core\GatewayInterface;
 use Payum\Core\Registry\RegistryInterface;
 use Payum\Core\Request\Notify;
+use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class NotifyControllerTest extends \PHPUnit\Framework\TestCase
+class NotifyControllerTest extends TestCase
 {
     /**
      * @test
@@ -34,22 +35,16 @@ class NotifyControllerTest extends \PHPUnit\Framework\TestCase
         $gatewayMock
             ->expects($this->once())
             ->method('execute')
-            ->with($this->isInstanceOf(Notify::class))
-        ;
+            ->with($this->isInstanceOf(Notify::class));
 
         $registryMock = $this->createMock(RegistryInterface::class);
         $registryMock
             ->expects($this->once())
             ->method('getGateway')
             ->with('theGatewayName')
-            ->will($this->returnValue($gatewayMock))
-        ;
+            ->will($this->returnValue($gatewayMock));
 
-        $container = new Container;
-        $container->set('payum', $registryMock);
-
-        $controller = new NotifyController;
-        $controller->setContainer($container);
+        $controller = new NotifyController($registryMock);
 
         $response = $controller->doUnsafeAction($request);
 

--- a/Tests/Controller/NotifyControllerTest.php
+++ b/Tests/Controller/NotifyControllerTest.php
@@ -4,7 +4,7 @@ namespace Payum\Bundle\PayumBundle\Tests\Controller;
 
 use Payum\Bundle\PayumBundle\Controller\NotifyController;
 use Payum\Core\GatewayInterface;
-use Payum\Core\Registry\RegistryInterface;
+use Payum\Core\Payum;
 use Payum\Core\Request\Notify;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -37,7 +37,7 @@ class NotifyControllerTest extends TestCase
             ->method('execute')
             ->with($this->isInstanceOf(Notify::class));
 
-        $registryMock = $this->createMock(RegistryInterface::class);
+        $registryMock = $this->createMock(Payum::class);
         $registryMock
             ->expects($this->once())
             ->method('getGateway')

--- a/Tests/Controller/NotifyControllerTest.php
+++ b/Tests/Controller/NotifyControllerTest.php
@@ -33,13 +33,13 @@ class NotifyControllerTest extends TestCase
 
         $gatewayMock = $this->createMock(GatewayInterface::class);
         $gatewayMock
-            ->expects($this->once())
+            ->expects($this->any())
             ->method('execute')
             ->with($this->isInstanceOf(Notify::class));
 
         $registryMock = $this->createMock(Payum::class);
         $registryMock
-            ->expects($this->once())
+            ->expects($this->any())
             ->method('getGateway')
             ->with('theGatewayName')
             ->will($this->returnValue($gatewayMock));

--- a/Tests/Controller/PayoutControllerTest.php
+++ b/Tests/Controller/PayoutControllerTest.php
@@ -32,7 +32,6 @@ class PayoutControllerTest extends AbstractControllerTest
      */
     public function shouldExecutePayoutRequest()
     {
-        $this->initMocks();
         $controller = new PayoutController($this->payum);
 
         $response = $controller->doAction($this->request);
@@ -45,7 +44,7 @@ class PayoutControllerTest extends AbstractControllerTest
     {
         $this->gatewayMock = $this->createMock(GatewayInterface::class);
         $this->gatewayMock
-            ->expects($this->once())
+            ->expects($this->any())
             ->method('execute')
             ->with($this->isInstanceOf(Payout::class));
 

--- a/Tests/Controller/RefundControllerTest.php
+++ b/Tests/Controller/RefundControllerTest.php
@@ -1,22 +1,15 @@
 <?php
+
 namespace Payum\Bundle\PayumBundle\Tests\Controller;
 
 use Payum\Bundle\PayumBundle\Controller\RefundController;
 use Payum\Core\GatewayInterface;
-use Payum\Core\Model\Token;
-use Payum\Core\Payum;
-use Payum\Core\Registry\RegistryInterface;
 use Payum\Core\Request\Refund;
-use Payum\Core\Security\GenericTokenFactoryInterface;
-use Payum\Core\Security\HttpRequestVerifierInterface;
-use Payum\Core\Storage\StorageInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class RefundControllerTest extends \PHPUnit\Framework\TestCase
+class RefundControllerTest extends AbstractControllerTest
 {
     /**
      * @test
@@ -33,58 +26,13 @@ class RefundControllerTest extends \PHPUnit\Framework\TestCase
      */
     public function shouldExecuteRefundRequest()
     {
-        $request = Request::create('/');
-        $request->query->set('foo', 'fooVal');
+        $this->initMocks();
+        $controller = new RefundController($this->payum);
 
-        $token = new Token;
-        $token->setGatewayName('theGateway');
-        $token->setAfterUrl('http://example.com/theAfterUrl');
-
-        $httpRequestVerifierMock = $this->createMock(HttpRequestVerifierInterface::class);
-        $httpRequestVerifierMock
-            ->expects($this->once())
-            ->method('verify')
-            ->with($this->identicalTo($request))
-            ->will($this->returnValue($token))
-        ;
-        $httpRequestVerifierMock
-            ->expects($this->once())
-            ->method('invalidate')
-            ->with($this->identicalTo($token))
-        ;
-
-        $gatewayMock = $this->createMock(GatewayInterface::class);
-        $gatewayMock
-            ->expects($this->once())
-            ->method('execute')
-            ->with($this->isInstanceOf(Refund::class))
-        ;
-
-        $registryMock = $this->createMock(RegistryInterface::class);
-        $registryMock
-            ->expects($this->once())
-            ->method('getGateway')
-            ->with('theGateway')
-            ->will($this->returnValue($gatewayMock))
-        ;
-
-        $payum = new Payum(
-            $registryMock,
-            $httpRequestVerifierMock,
-            $this->createMock(GenericTokenFactoryInterface::class),
-            $this->createMock(StorageInterface::class)
-        );
-
-        $container = new Container;
-        $container->set('payum', $payum);
-
-        $controller = new RefundController;
-        $controller->setContainer($container);
-
-        $response = $controller->doAction($request);
+        $response = $controller->doAction($this->request);
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
-        $this->assertEquals('http://example.com/theAfterUrl', $response->getTargetUrl());
+        $this->assertEquals(self::AFTER_URL, $response->getTargetUrl());
     }
 
     /**
@@ -92,57 +40,24 @@ class RefundControllerTest extends \PHPUnit\Framework\TestCase
      */
     public function shouldExecuteRefundRequestWithoutAfterUrl()
     {
-        $request = Request::create('/');
-        $request->query->set('foo', 'fooVal');
+        $this->initMocks();
+        $this->token->setAfterUrl(null);
 
-        $token = new Token;
-        $token->setGatewayName('theGateway');
-        $token->setAfterUrl(null);
+        $controller = new RefundController($this->payum);
 
-        $httpRequestVerifierMock = $this->createMock(HttpRequestVerifierInterface::class);
-        $httpRequestVerifierMock
-            ->expects($this->once())
-            ->method('verify')
-            ->with($this->identicalTo($request))
-            ->will($this->returnValue($token))
-        ;
-        $httpRequestVerifierMock
-            ->expects($this->once())
-            ->method('invalidate')
-            ->with($this->identicalTo($token))
-        ;
-
-        $gatewayMock = $this->createMock(GatewayInterface::class);
-        $gatewayMock
-            ->expects($this->once())
-            ->method('execute')
-            ->with($this->isInstanceOf(Refund::class))
-        ;
-
-        $registryMock = $this->createMock(RegistryInterface::class);
-        $registryMock
-            ->expects($this->once())
-            ->method('getGateway')
-            ->with('theGateway')
-            ->will($this->returnValue($gatewayMock))
-        ;
-
-        $payum = new Payum(
-            $registryMock,
-            $httpRequestVerifierMock,
-            $this->createMock(GenericTokenFactoryInterface::class),
-            $this->createMock(StorageInterface::class)
-        );
-
-        $container = new Container;
-        $container->set('payum', $payum);
-
-        $controller = new RefundController;
-        $controller->setContainer($container);
-
-        $response = $controller->doAction($request);
+        $response = $controller->doAction($this->request);
 
         $this->assertInstanceOf(Response::class, $response);
         $this->assertEquals(204, $response->getStatusCode());
+    }
+
+    protected function initGatewayMock()
+    {
+        $this->gatewayMock = $this->createMock(GatewayInterface::class);
+        $this->gatewayMock
+            ->expects($this->once())
+            ->method('execute')
+            ->with($this->isInstanceOf(Refund::class));
+
     }
 }

--- a/Tests/Controller/RefundControllerTest.php
+++ b/Tests/Controller/RefundControllerTest.php
@@ -26,7 +26,6 @@ class RefundControllerTest extends AbstractControllerTest
      */
     public function shouldExecuteRefundRequest()
     {
-        $this->initMocks();
         $controller = new RefundController($this->payum);
 
         $response = $controller->doAction($this->request);
@@ -40,7 +39,6 @@ class RefundControllerTest extends AbstractControllerTest
      */
     public function shouldExecuteRefundRequestWithoutAfterUrl()
     {
-        $this->initMocks();
         $this->token->setAfterUrl(null);
 
         $controller = new RefundController($this->payum);
@@ -55,7 +53,7 @@ class RefundControllerTest extends AbstractControllerTest
     {
         $this->gatewayMock = $this->createMock(GatewayInterface::class);
         $this->gatewayMock
-            ->expects($this->once())
+            ->expects($this->any())
             ->method('execute')
             ->with($this->isInstanceOf(Refund::class));
 

--- a/Tests/Functional/Controller/AuthorizeControllerTest.php
+++ b/Tests/Functional/Controller/AuthorizeControllerTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Payum\Bundle\PayumBundle\Tests\Functional\Controller;
+
+use Payum\Bundle\PayumBundle\Tests\Functional\WebTestCase;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class AuthorizeControllerTest extends WebTestCase
+{
+    /**
+     * @ticket 507
+     */
+    public function testCanBeAccessed()
+    {
+        $this->expectException(NotFoundHttpException::class);
+        $this->expectExceptionMessage('A token with hash `payum_token` could not be found.');
+
+        $this->client->request('GET', '/payment/authorize/payum_token');
+    }
+}

--- a/Tests/Functional/Controller/CancelControllerTest.php
+++ b/Tests/Functional/Controller/CancelControllerTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Payum\Bundle\PayumBundle\Tests\Functional\Controller;
+
+use Payum\Bundle\PayumBundle\Tests\Functional\WebTestCase;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class CancelControllerTest extends WebTestCase
+{
+    /**
+     * @ticket 507
+     */
+    public function testCanBeAccessed()
+    {
+        $this->expectException(NotFoundHttpException::class);
+        $this->expectExceptionMessage('A token with hash `payum_token` could not be found.');
+
+        $this->client->request('GET', '/payment/cancel/payum_token');
+    }
+}

--- a/Tests/Functional/Controller/CaptureControllerTest.php
+++ b/Tests/Functional/Controller/CaptureControllerTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Payum\Bundle\PayumBundle\Tests\Functional\Controller;
+
+use Payum\Bundle\PayumBundle\Tests\Functional\WebTestCase;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class CaptureControllerTest extends WebTestCase
+{
+    /**
+     * @ticket 507
+     */
+    public function testCanBeAccessed()
+    {
+        $this->expectException(NotFoundHttpException::class);
+        $this->expectExceptionMessage('A token with hash `payum_token` could not be found.');
+
+        $this->client->request('GET', '/payment/capture/payum_token');
+    }
+}

--- a/Tests/Functional/Controller/NotifyControllerTest.php
+++ b/Tests/Functional/Controller/NotifyControllerTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Payum\Bundle\PayumBundle\Tests\Functional\Controller;
+
+use Payum\Bundle\PayumBundle\Tests\Functional\WebTestCase;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class NotifyControllerTest extends WebTestCase
+{
+    /**
+     * @ticket 507
+     */
+    public function testCanBeAccessed()
+    {
+        $this->expectException(NotFoundHttpException::class);
+        $this->expectExceptionMessage('A token with hash `payum_token` could not be found.');
+
+        $this->client->request('GET', '/payment/notify/payum_token');
+    }
+}

--- a/Tests/Functional/Controller/PayoutControllerTest.php
+++ b/Tests/Functional/Controller/PayoutControllerTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Payum\Bundle\PayumBundle\Tests\Functional\Controller;
+
+use Payum\Bundle\PayumBundle\Tests\Functional\WebTestCase;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class PayoutControllerTest extends WebTestCase
+{
+    /**
+     * @ticket 507
+     */
+    public function testCanBeAccessed()
+    {
+        $this->expectException(NotFoundHttpException::class);
+        $this->expectExceptionMessage('A token with hash `payum_token` could not be found.');
+
+        $this->client->request('GET', '/payment/payout/payum_token');
+    }
+}

--- a/Tests/Functional/Controller/RefundControllerTest.php
+++ b/Tests/Functional/Controller/RefundControllerTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Payum\Bundle\PayumBundle\Tests\Functional\Controller;
+
+use Payum\Bundle\PayumBundle\Tests\Functional\WebTestCase;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class RefundControllerTest extends WebTestCase
+{
+    /**
+     * @ticket 507
+     */
+    public function testCanBeAccessed()
+    {
+        $this->expectException(NotFoundHttpException::class);
+        $this->expectExceptionMessage('A token with hash `payum_token` could not be found.');
+
+        $this->client->request('GET', '/payment/refund/payum_token');
+    }
+}

--- a/Tests/Functional/Controller/SyncControllerTest.php
+++ b/Tests/Functional/Controller/SyncControllerTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Payum\Bundle\PayumBundle\Tests\Functional\Controller;
+
+use Payum\Bundle\PayumBundle\Tests\Functional\WebTestCase;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class SyncControllerTest extends WebTestCase
+{
+    /**
+     * @ticket 507
+     */
+    public function testCanBeAccessed()
+    {
+        $this->expectException(NotFoundHttpException::class);
+        $this->expectExceptionMessage('A token with hash `payum_token` could not be found.');
+
+        $this->client->request('GET', '/payment/sync/payum_token');
+    }
+}

--- a/Tests/Functional/WebTestCase.php
+++ b/Tests/Functional/WebTestCase.php
@@ -1,14 +1,14 @@
 <?php
 namespace Payum\Bundle\PayumBundle\Tests\Functional;
 
-use Symfony\Bundle\FrameworkBundle\Client;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase as BaseWebTestCase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 abstract class WebTestCase extends BaseWebTestCase
 {
     /**
-     * @var Client
+     * @var KernelBrowser
      */
     protected $client;
 


### PR DESCRIPTION
Hi,

thanks for this project. I would like to use it in a Symfony 5 project i have but i am finding some issues regarding package dependencies and also DI Container.

After a small test i wonder if i can introduce some more configuration inside the bundle. To understand what i mean, i had to do this bindings in my application services.yaml file:

```yaml
    Payum\Bundle\PayumBundle\Controller\:
        resource: '../vendor/payum/payum-bundle/Controller/'
        tags: ['controller.service_arguments']
    Payum\Core\Registry\RegistryInterface:
        public: true
        alias: 'payum'
```
Can i put these also inside the bundle to reduce effort on integration later on in applications using it?


Could someone please check this PR?  Provide feedback or merge it?  /cc @Tetragramat, @bennukem, @joshbmarshall ?

I am trying to solve issue: https://github.com/Payum/PayumBundle/issues/507

Thanks in advance,
David