### PR TITLE
Use Symfony service to register templates instead of TwigUtil

### DIFF
--- a/DependencyInjection/Compiler/BuildConfigsPass.php
+++ b/DependencyInjection/Compiler/BuildConfigsPass.php
@@ -23,8 +23,10 @@ class BuildConfigsPass implements CompilerPassInterface
 
         $builder = $container->getDefinition('payum.builder');
         if ($container->hasDefinition('twig')) {
-            $config = ['twig.env' => '@twig'];
-
+            $config = [
+                'twig.env' => '@twig',
+                'twig.register_paths' => '@payum.twig.path_registrar'
+            ];
             $builder->addMethodCall('addCoreGatewayFactoryConfig', [$config]);
         }
 

--- a/DependencyInjection/PayumExtension.php
+++ b/DependencyInjection/PayumExtension.php
@@ -53,6 +53,11 @@ class PayumExtension extends Extension implements PrependExtensionInterface
         $loader->load('commands.xml');
         $loader->load('form.xml');
 
+        $bundles = $container->getParameter('kernel.bundles');
+        if (isset($bundles['TwigBundle'])) {
+            $loader->load('twig.xml');
+        }
+
         if ($container->getParameter('kernel.debug')) {
             $loader->load('debug.xml');
         }

--- a/Resources/config/twig.xml
+++ b/Resources/config/twig.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="payum.twig.path_registrar" class="Payum\Bundle\PayumBundle\Twig\PathRegistrar" public="true">
+            <argument id="twig" type="service" />
+        </service>
+    </services>
+</container>

--- a/Tests/DependencyInjection/Compiler/BuildConfigsPassTest.php
+++ b/Tests/DependencyInjection/Compiler/BuildConfigsPassTest.php
@@ -212,4 +212,35 @@ class BuildConfigsPassTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals($expected, $builder->getMethodCalls());
     }
+
+    public function testShouldAddTwigPathRegistrar()
+    {
+        $builder = new Definition();
+        $twig = new Definition();
+
+        $container = new ContainerBuilder();
+        $container->setDefinition('payum.builder', $builder);
+        $container->setDefinition('twig', $twig);
+        $pass = new BuildConfigsPass();
+
+        $pass->process($container);
+
+        $calls = $builder->getMethodCalls();
+
+        $this->assertEquals(#
+            $calls,
+            [
+                [
+                    'addCoreGatewayFactoryConfig',
+                    [
+                        [
+                            'twig.env' => '@twig',
+                            'twig.register_paths' => '@payum.twig.path_registrar'
+                        ]
+                    ]
+                ]
+            ]
+        );
+
+    }
 }

--- a/Tests/Functional/DependencyInjection/PayumExtensionTest.php
+++ b/Tests/Functional/DependencyInjection/PayumExtensionTest.php
@@ -89,6 +89,7 @@ class PayumExtensionTest extends TestCase
 
         $containerBuilder = new ContainerBuilder();
         $containerBuilder->setParameter('kernel.debug', false);
+        $containerBuilder->setParameter('kernel.bundles', []);
 
         $extension = new PayumExtension;
 
@@ -137,6 +138,7 @@ class PayumExtensionTest extends TestCase
 
         $containerBuilder = new ContainerBuilder();
         $containerBuilder->setParameter('kernel.debug', false);
+        $containerBuilder->setParameter('kernel.bundles', []);
 
         $extension = new PayumExtension;
 
@@ -186,21 +188,22 @@ class PayumExtensionTest extends TestCase
 
         $configs = array($config);
 
-        $container = new ContainerBuilder();
-        $container->setParameter('kernel.debug', false);
+        $containerBuilder = new ContainerBuilder();
+        $containerBuilder->setParameter('kernel.debug', false);
+        $containerBuilder->setParameter('kernel.bundles', []);
 
         $extension = new PayumExtension;
 
-        $extension->load($configs, $container);
+        $extension->load($configs, $containerBuilder);
 
-        $this->assertTrue($container->hasDefinition('payum.dynamic_gateways.cypher'));
-        $cypher = $container->getDefinition('payum.dynamic_gateways.cypher');
+        $this->assertTrue($containerBuilder->hasDefinition('payum.dynamic_gateways.cypher'));
+        $cypher = $containerBuilder->getDefinition('payum.dynamic_gateways.cypher');
         $this->assertSame(DefuseCypher::class, $cypher->getClass());
         $this->assertSame('aSecretKey', $cypher->getArgument(0));
 
-        $this->assertTrue($container->hasDefinition('payum.dynamic_gateways.encrypted_config_storage'));
+        $this->assertTrue($containerBuilder->hasDefinition('payum.dynamic_gateways.encrypted_config_storage'));
 
-        $storage = $container->getDefinition('payum.dynamic_gateways.encrypted_config_storage');
+        $storage = $containerBuilder->getDefinition('payum.dynamic_gateways.encrypted_config_storage');
         $this->assertSame(CryptoStorageDecorator::class, $storage->getClass());
         $this->assertSame('payum.dynamic_gateways.encrypted_config_storage.inner', (string) $storage->getArgument(0));
         $this->assertSame('payum.dynamic_gateways.cypher', (string) $storage->getArgument(1));
@@ -243,6 +246,7 @@ class PayumExtensionTest extends TestCase
 
         $containerBuilder = new ContainerBuilder();
         $containerBuilder->setParameter('kernel.debug', false);
+        $containerBuilder->setParameter('kernel.bundles', []);
 
         $extension = new PayumExtension;
 
@@ -301,6 +305,7 @@ class PayumExtensionTest extends TestCase
 
         $containerBuilder = new ContainerBuilder();
         $containerBuilder->setParameter('kernel.debug', false);
+        $containerBuilder->setParameter('kernel.bundles', []);
 
         $extension = new PayumExtension;
 
@@ -351,6 +356,7 @@ class PayumExtensionTest extends TestCase
 
         $containerBuilder = new ContainerBuilder();
         $containerBuilder->setParameter('kernel.debug', false);
+        $containerBuilder->setParameter('kernel.bundles', []);
 
         $extension = new PayumExtension;
 
@@ -358,6 +364,71 @@ class PayumExtensionTest extends TestCase
 
         $this->assertFalse($containerBuilder->hasDefinition('payum.dynamic_gateways.gateway_config_admin'));
     }
+
+    /**
+     * @test
+     */
+    public function shouldConfigureTwigPathRegistrar()
+    {
+        $config = array(
+            'security' => array(
+                'token_storage' => array(
+                    'Payum\Core\Model\Token' => array(
+                        'filesystem' => array(
+                            'storage_dir' => sys_get_temp_dir(),
+                            'id_property' => 'hash'
+                        )
+                    )
+                )
+            ),
+            'gateways' => array(),
+        );
+
+        $configs = array($config);
+
+        $containerBuilder = new ContainerBuilder();
+        $containerBuilder->setParameter('kernel.debug', false);
+        $containerBuilder->setParameter('kernel.bundles', ['TwigBundle' => 'TwigBundle']);
+
+        $extension = new PayumExtension;
+
+        $extension->load($configs, $containerBuilder);
+
+        $this->assertTrue($containerBuilder->hasDefinition('payum.twig.path_registrar'));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotConfigureTwigPathRegistrarWithoutTwig()
+    {
+        $config = array(
+            'security' => array(
+                'token_storage' => array(
+                    'Payum\Core\Model\Token' => array(
+                        'filesystem' => array(
+                            'storage_dir' => sys_get_temp_dir(),
+                            'id_property' => 'hash'
+                        )
+                    )
+                )
+            ),
+            'gateways' => array(),
+        );
+
+        $configs = array($config);
+
+        $containerBuilder = new ContainerBuilder();
+        $containerBuilder->setParameter('kernel.debug', false);
+        $containerBuilder->setParameter('kernel.bundles', []);
+
+        $extension = new PayumExtension;
+
+        $extension->load($configs, $containerBuilder);
+
+        $this->assertFalse($containerBuilder->hasDefinition('payum.twig.path_registrar'));
+    }
+
 }
 
 class TestGatewayConfig implements GatewayConfigInterface

--- a/Tests/Functional/Twig/PathRegistrarTest.php
+++ b/Tests/Functional/Twig/PathRegistrarTest.php
@@ -1,0 +1,44 @@
+<?php
+
+
+namespace Functional\Twig;
+
+
+use Payum\Bundle\PayumBundle\Tests\Functional\WebTestCase;
+use Payum\Core\Payum;
+use Twig\Environment;
+
+class PathRegistrarTest extends WebTestCase
+{
+    /**
+     * @var Environment
+     */
+    private $twig;
+
+    /**
+     * @var Payum
+     */
+    private $payum;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->twig = static::$container->get('twig');
+        $this->payum = static::$container->get('payum');
+    }
+
+
+    public function testPathsAreConfigured()
+    {
+        $this->payum->getGateway('barGateway');
+
+        $templateContent = $this->twig->render('@PayumPaypalExpressCheckout/confirmOrder.html.twig');
+
+        $this->assertContains(
+            '<input type="submit" name="confirm" value="I confirm order purchase">',
+            $templateContent
+        );
+    }
+
+}

--- a/Twig/PathRegistrar.php
+++ b/Twig/PathRegistrar.php
@@ -1,0 +1,43 @@
+<?php
+
+
+namespace Payum\Bundle\PayumBundle\Twig;
+
+
+use Payum\Core\Bridge\Spl\ArrayObject;
+use Twig\Loader\ChainLoader;
+use Twig\Loader\FilesystemLoader;
+
+class PathRegistrar
+{
+    /**
+     * @var FilesystemLoader
+     */
+    protected $fileLoader;
+
+    public function __construct($twig)
+    {
+        $this->fileLoader = new FilesystemLoader();
+
+        $currentLoader = $twig->getLoader();
+        if ($currentLoader instanceof ChainLoader) {
+            $currentLoader->addLoader($this->fileLoader);
+        } else {
+            $twig->setLoader(new ChainLoader([$currentLoader, $this->fileLoader]));
+        }
+    }
+
+    public function register(ArrayObject $config)
+    {
+        $paths = $config['payum.paths'];
+
+        foreach ($paths as $namespace => $path) {
+            $this->fileLoader->addPath($path, $namespace);
+        }
+    }
+
+    public function __invoke()
+    {
+        return call_user_func_array([$this, 'register'], func_get_args());
+    }
+}


### PR DESCRIPTION
TwigUtil uses a static SplObjectStorage when registering templates.
This leads to memory leaks when you have a lot of funtional tests.
Registering templates through a service avoids that memory leak.