### PR TITLE
Feature/update phpunit 8 to 9

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,10 +14,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php: 7.2
-          - php: 7.3
           - php: 7.4
           - php: 8.0
+          - php: 8.1
 
     steps:
       - name: Checkout
@@ -43,8 +42,8 @@ jobs:
       - name: Install PHP 8 dependencies
         if: startsWith(matrix.php, '8')
         run: |
-            composer req --dev --no-update payum/payum:dev-master
-            composer rem --dev --no-update league/uri-schemes
+          composer req --dev --no-update payum/payum:dev-master
+          composer rem --dev --no-update league/uri-schemes
 
       - name: Install dependencies
         run: composer update
@@ -60,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php: 7.2
+          - php: 7.4
 
     steps:
       - name: Checkout

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -39,12 +39,6 @@ jobs:
           key: ${{ runner.os }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json composer.lock') }}
           restore-keys: ${{ runner.os }}-php-${{ matrix.php }}-composer-
 
-      - name: Install PHP 8 dependencies
-        if: startsWith(matrix.php, '8')
-        run: |
-          composer req --dev --no-update payum/payum:dev-master
-          composer rem --dev --no-update league/uri-schemes
-
       - name: Install dependencies
         run: composer update
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ composer.phar
 composer.lock
 vendor
 bin
+.phpunit.result.cache

--- a/Tests/Controller/AbstractControllerTest.php
+++ b/Tests/Controller/AbstractControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Payum\Bundle\PayumBundle\Tests\Controller;
 
+use Payum\Core\GatewayInterface;
 use Payum\Core\Model\Token;
 use Payum\Core\Payum;
 use Payum\Core\Registry\RegistryInterface;
@@ -16,12 +17,12 @@ abstract class AbstractControllerTest extends TestCase
     protected const GATEWAY_NAME = 'theGateway';
     protected const AFTER_URL = 'http://example.com/theAfterUrl';
 
-    protected $token;
-    protected $httpRequestVerifierMock;
-    protected $gatewayMock;
-    protected $registryMock;
-    protected $payum;
-    protected $request;
+    protected Token $token;
+    protected HttpRequestVerifierInterface $httpRequestVerifierMock;
+    protected GatewayInterface $gatewayMock;
+    protected RegistryInterface $registryMock;
+    protected Payum $payum;
+    protected Request $request;
 
     protected function setUp(): void
     {
@@ -63,5 +64,5 @@ abstract class AbstractControllerTest extends TestCase
         );
     }
 
-    protected abstract function initGatewayMock();
+    abstract protected function initGatewayMock();
 }

--- a/Tests/Controller/AbstractControllerTest.php
+++ b/Tests/Controller/AbstractControllerTest.php
@@ -9,6 +9,7 @@ use Payum\Core\Registry\RegistryInterface;
 use Payum\Core\Security\GenericTokenFactoryInterface;
 use Payum\Core\Security\HttpRequestVerifierInterface;
 use Payum\Core\Storage\StorageInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -18,9 +19,16 @@ abstract class AbstractControllerTest extends TestCase
     protected const AFTER_URL = 'http://example.com/theAfterUrl';
 
     protected Token $token;
-    protected HttpRequestVerifierInterface $httpRequestVerifierMock;
-    protected GatewayInterface $gatewayMock;
-    protected RegistryInterface $registryMock;
+
+    /** @var RegistryInterface&MockObject */
+    protected $httpRequestVerifierMock;
+
+    /** @var GatewayInterface&MockObject */
+    protected $gatewayMock;
+
+    /** @var RegistryInterface&MockObject */
+    protected $registryMock;
+
     protected Payum $payum;
     protected Request $request;
 

--- a/Tests/Controller/AuthorizeControllerTest.php
+++ b/Tests/Controller/AuthorizeControllerTest.php
@@ -13,7 +13,7 @@ class AuthorizeControllerTest extends AbstractControllerTest
     /**
      * @test
      */
-    public function shouldBeSubClassOfController()
+    public function shouldBeSubClassOfController(): void
     {
         $rc = new \ReflectionClass(AuthorizeController::class);
 
@@ -23,7 +23,7 @@ class AuthorizeControllerTest extends AbstractControllerTest
     /**
      * @test
      */
-    public function shouldExecuteAuthorizeRequest()
+    public function shouldExecuteAuthorizeRequest(): void
     {
         $controller = new AuthorizeController();
         $controller->setContainer(new ServiceLocator(['payum' => function () { return $this->payum; }]));
@@ -34,7 +34,7 @@ class AuthorizeControllerTest extends AbstractControllerTest
         $this->assertEquals(self::AFTER_URL, $response->getTargetUrl());
     }
 
-    protected function initGatewayMock()
+    protected function initGatewayMock(): void
     {
         $this->gatewayMock = $this->createMock(GatewayInterface::class);
         $this->gatewayMock

--- a/Tests/Controller/CancelControllerTest.php
+++ b/Tests/Controller/CancelControllerTest.php
@@ -14,7 +14,7 @@ class CancelControllerTest extends AbstractControllerTest
     /**
      * @test
      */
-    public function shouldBeSubClassOfController()
+    public function shouldBeSubClassOfController(): void
     {
         $rc = new \ReflectionClass(CancelController::class);
 
@@ -24,7 +24,7 @@ class CancelControllerTest extends AbstractControllerTest
     /**
      * @test
      */
-    public function shouldExecuteCancelRequest()
+    public function shouldExecuteCancelRequest(): void
     {
         $controller = new CancelController();
         $controller->setContainer(new ServiceLocator(['payum' => function () { return $this->payum; }]));
@@ -38,7 +38,7 @@ class CancelControllerTest extends AbstractControllerTest
     /**
      * @test
      */
-    public function shouldExecuteCancelRequestWithoutAfterUrl()
+    public function shouldExecuteCancelRequestWithoutAfterUrl(): void
     {
         $this->token->setAfterUrl(null);
 
@@ -51,7 +51,7 @@ class CancelControllerTest extends AbstractControllerTest
         $this->assertEquals(204, $response->getStatusCode());
     }
 
-    protected function initGatewayMock()
+    protected function initGatewayMock(): void
     {
         $this->gatewayMock = $this->createMock(GatewayInterface::class);
         $this->gatewayMock

--- a/Tests/Controller/CaptureControllerTest.php
+++ b/Tests/Controller/CaptureControllerTest.php
@@ -19,7 +19,7 @@ class CaptureControllerTest extends AbstractControllerTest
     /**
      * @test
      */
-    public function shouldBeSubClassOfController()
+    public function shouldBeSubClassOfController(): void
     {
         $rc = new \ReflectionClass(CaptureController::class);
 
@@ -29,11 +29,13 @@ class CaptureControllerTest extends AbstractControllerTest
     /**
      * @test
      *
-     * @expectedException \Symfony\Component\HttpKernel\Exception\HttpException
-     * @expectedExceptionMessage This controller requires session to be started.
+     *
+     *
      */
-    public function throwBadRequestIfSessionNotStartedOnDoSessionAction()
+    public function throwBadRequestIfSessionNotStartedOnDoSessionAction(): void
     {
+        $this->expectExceptionMessage("This controller requires session to be started.");
+        $this->expectException(\Symfony\Component\HttpKernel\Exception\HttpException::class);
         $this->registryMock = $this->createMock(RegistryInterface::class);
         $this->httpRequestVerifierMock = $this->createMock(
             HttpRequestVerifierInterface::class
@@ -53,11 +55,13 @@ class CaptureControllerTest extends AbstractControllerTest
     /**
      * @test
      *
-     * @expectedException \Symfony\Component\HttpKernel\Exception\HttpException
-     * @expectedExceptionMessage This controller requires token hash to be stored in the session.
+     *
+     *
      */
-    public function throwBadRequestIfSessionNotContainPayumTokenOnDoSessionAction()
+    public function throwBadRequestIfSessionNotContainPayumTokenOnDoSessionAction(): void
     {
+        $this->expectExceptionMessage("This controller requires token hash to be stored in the session.");
+        $this->expectException(\Symfony\Component\HttpKernel\Exception\HttpException::class);
         $this->registryMock = $this->createMock(RegistryInterface::class);
         $this->httpRequestVerifierMock = $this->createMock(
             HttpRequestVerifierInterface::class
@@ -75,7 +79,7 @@ class CaptureControllerTest extends AbstractControllerTest
     /**
      * @test
      */
-    public function shouldDoRedirectToCaptureWithTokenUrl()
+    public function shouldDoRedirectToCaptureWithTokenUrl(): void
     {
         $routerMock = $this->createMock(RouterInterface::class);
         $routerMock
@@ -116,7 +120,7 @@ class CaptureControllerTest extends AbstractControllerTest
     /**
      * @test
      */
-    public function shouldExecuteCaptureRequest()
+    public function shouldExecuteCaptureRequest(): void
     {
         $controller = new CaptureController();
         $controller->setContainer(new ServiceLocator(['payum' => function () { return $this->payum; }]));
@@ -127,7 +131,7 @@ class CaptureControllerTest extends AbstractControllerTest
         $this->assertEquals(self::AFTER_URL, $response->getTargetUrl());
     }
 
-    protected function initGatewayMock()
+    protected function initGatewayMock(): void
     {
         $this->gatewayMock = $this->createMock(GatewayInterface::class);
         $this->gatewayMock

--- a/Tests/Controller/CaptureControllerTest.php
+++ b/Tests/Controller/CaptureControllerTest.php
@@ -28,9 +28,6 @@ class CaptureControllerTest extends AbstractControllerTest
 
     /**
      * @test
-     *
-     *
-     *
      */
     public function throwBadRequestIfSessionNotStartedOnDoSessionAction(): void
     {
@@ -54,9 +51,6 @@ class CaptureControllerTest extends AbstractControllerTest
 
     /**
      * @test
-     *
-     *
-     *
      */
     public function throwBadRequestIfSessionNotContainPayumTokenOnDoSessionAction(): void
     {

--- a/Tests/Controller/NotifyControllerTest.php
+++ b/Tests/Controller/NotifyControllerTest.php
@@ -17,7 +17,7 @@ class NotifyControllerTest extends TestCase
     /**
      * @test
      */
-    public function shouldBeSubClassOfController()
+    public function shouldBeSubClassOfController(): void
     {
         $rc = new \ReflectionClass(NotifyController::class);
 
@@ -27,7 +27,7 @@ class NotifyControllerTest extends TestCase
     /**
      * @test
      */
-    public function shouldExecuteNotifyRequestOnDoUnsafe()
+    public function shouldExecuteNotifyRequestOnDoUnsafe(): void
     {
         $request = Request::create('/');
         $request->query->set('gateway', 'theGatewayName');

--- a/Tests/Controller/PayoutControllerTest.php
+++ b/Tests/Controller/PayoutControllerTest.php
@@ -13,7 +13,7 @@ class PayoutControllerTest extends AbstractControllerTest
     /**
      * @test
      */
-    public function shouldBeSubClassOfController()
+    public function shouldBeSubClassOfController(): void
     {
         $rc = new \ReflectionClass(PayoutController::class);
 
@@ -23,7 +23,7 @@ class PayoutControllerTest extends AbstractControllerTest
     /**
      * @test
      */
-    public function shouldExecutePayoutRequest()
+    public function shouldExecutePayoutRequest(): void
     {
         $controller = new PayoutController();
         $controller->setContainer(new ServiceLocator(['payum' => function () { return $this->payum; }]));
@@ -34,7 +34,7 @@ class PayoutControllerTest extends AbstractControllerTest
         $this->assertEquals(self::AFTER_URL, $response->getTargetUrl());
     }
 
-    protected function initGatewayMock()
+    protected function initGatewayMock(): void
     {
         $this->gatewayMock = $this->createMock(GatewayInterface::class);
         $this->gatewayMock

--- a/Tests/Controller/RefundControllerTest.php
+++ b/Tests/Controller/RefundControllerTest.php
@@ -15,7 +15,7 @@ class RefundControllerTest extends AbstractControllerTest
     /**
      * @test
      */
-    public function shouldBeSubClassOfController()
+    public function shouldBeSubClassOfController(): void
     {
         $rc = new \ReflectionClass(RefundController::class);
 
@@ -25,7 +25,7 @@ class RefundControllerTest extends AbstractControllerTest
     /**
      * @test
      */
-    public function shouldExecuteRefundRequest()
+    public function shouldExecuteRefundRequest(): void
     {
         $controller = new RefundController();
         $controller->setContainer(new ServiceLocator(['payum' => function () { return $this->payum; }]));
@@ -39,7 +39,7 @@ class RefundControllerTest extends AbstractControllerTest
     /**
      * @test
      */
-    public function shouldExecuteRefundRequestWithoutAfterUrl()
+    public function shouldExecuteRefundRequestWithoutAfterUrl(): void
     {
         $this->token->setAfterUrl(null);
 
@@ -52,7 +52,7 @@ class RefundControllerTest extends AbstractControllerTest
         $this->assertEquals(204, $response->getStatusCode());
     }
 
-    protected function initGatewayMock()
+    protected function initGatewayMock(): void
     {
         $this->gatewayMock = $this->createMock(GatewayInterface::class);
         $this->gatewayMock

--- a/Tests/DependencyInjection/Compiler/BuildConfigsPassTest.php
+++ b/Tests/DependencyInjection/Compiler/BuildConfigsPassTest.php
@@ -8,7 +8,7 @@ use Symfony\Component\DependencyInjection\Definition;
 
 class BuildConfigsPassTest extends \PHPUnit\Framework\TestCase
 {
-    public function provideTags()
+    public function provideTags(): array
     {
         return [
             0 => [['name' => 'payum.action'], []],
@@ -182,7 +182,7 @@ class BuildConfigsPassTest extends \PHPUnit\Framework\TestCase
         ];
     }
 
-    public function testShouldImplementCompilerPassInterface()
+    public function testShouldImplementCompilerPassInterface(): void
     {
         $rc = new \ReflectionClass(BuildConfigsPass::class);
 
@@ -192,7 +192,7 @@ class BuildConfigsPassTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider provideTags
      */
-    public function testShouldAddConfig(array $tagAttributes, $expected)
+    public function testShouldAddConfig(array $tagAttributes, $expected): void
     {
         $tagName = $tagAttributes['name'];
         unset($tagAttributes['name']);

--- a/Tests/DependencyInjection/Compiler/BuildGatewayFactoriesBuilderPassTest.php
+++ b/Tests/DependencyInjection/Compiler/BuildGatewayFactoriesBuilderPassTest.php
@@ -11,14 +11,14 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class BuildGatewayFactoriesBuilderPassTest extends \PHPUnit\Framework\TestCase
 {
-    public function testShouldImplementCompilerPassInterface()
+    public function testShouldImplementCompilerPassInterface(): void
     {
         $rc = new \ReflectionClass(BuildGatewayFactoriesBuilderPass::class);
 
         $this->assertTrue($rc->implementsInterface(CompilerPassInterface::class));
     }
 
-    public function testShouldAddServiceWithTagToPayumBuilder()
+    public function testShouldAddServiceWithTagToPayumBuilder(): void
     {
         $service = new Definition();
         $service->addTag('payum.gateway_factory_builder', ['factory' => 'fooFactory']);
@@ -40,12 +40,10 @@ class BuildGatewayFactoriesBuilderPassTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('aservice', (string) $calls[0][1][1]);
     }
 
-    /**
-     * @expectedException \Payum\Core\Exception\LogicException
-     * @expectedExceptionMessage The payum.gateway_factory tag require factory attribute.
-     */
-    public function testThrowIfTagMissFactoryAttribute()
+    public function testThrowIfTagMissFactoryAttribute(): void
     {
+        $this->expectExceptionMessage("The payum.gateway_factory tag require factory attribute.");
+        $this->expectException(\Payum\Core\Exception\LogicException::class);
         $service = new Definition();
         $service->addTag('payum.gateway_factory_builder');
 

--- a/Tests/DependencyInjection/Compiler/BuildGatewayFactoriesPassTest.php
+++ b/Tests/DependencyInjection/Compiler/BuildGatewayFactoriesPassTest.php
@@ -9,14 +9,14 @@ use Symfony\Component\DependencyInjection\Definition;
 
 class BuildGatewayFactoriesPassTest extends \PHPUnit\Framework\TestCase
 {
-    public function testShouldImplementCompilerPassInterface()
+    public function testShouldImplementCompilerPassInterface(): void
     {
         $rc = new \ReflectionClass(BuildConfigsPass::class);
 
         $this->assertTrue($rc->implementsInterface(CompilerPassInterface::class));
     }
 
-    public function testShouldAddServiceWithTagToStaticRegistry()
+    public function testShouldAddServiceWithTagToStaticRegistry(): void
     {
         $service = new Definition();
         $service->addTag('payum.gateway_factory', ['factory' => 'foo']);
@@ -34,12 +34,10 @@ class BuildGatewayFactoriesPassTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(['foo' => 'aservice'], $registry->getArgument(2));
     }
 
-    /**
-     * @expectedException \Payum\Core\Exception\LogicException
-     * @expectedExceptionMessage The payum.gateway_factory tag require factory attribute.
-     */
-    public function testThrowIfTagMissFactoryAttribute()
+    public function testThrowIfTagMissFactoryAttribute(): void
     {
+        $this->expectException(\Payum\Core\Exception\LogicException::class);
+        $this->expectExceptionMessage("The payum.gateway_factory tag require factory attribute.");
         $service = new Definition();
         $service->addTag('payum.gateway_factory');
 

--- a/Tests/DependencyInjection/Compiler/BuildGatewaysPassTest.php
+++ b/Tests/DependencyInjection/Compiler/BuildGatewaysPassTest.php
@@ -8,14 +8,14 @@ use Symfony\Component\DependencyInjection\Definition;
 
 class BuildGatewaysPassTest extends \PHPUnit\Framework\TestCase
 {
-    public function testShouldImplementCompilerPassInterface()
+    public function testShouldImplementCompilerPassInterface(): void
     {
         $rc = new \ReflectionClass(BuildGatewaysPass::class);
 
         $this->assertTrue($rc->implementsInterface(CompilerPassInterface::class));
     }
 
-    public function testShouldAddServiceWithTagToStaticRegistry()
+    public function testShouldAddServiceWithTagToStaticRegistry(): void
     {
         $service = new Definition();
         $service->addTag('payum.gateway', ['gateway' => 'foo']);
@@ -33,12 +33,10 @@ class BuildGatewaysPassTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(['foo' => 'aservice'], $registry->getArgument(0));
     }
 
-    /**
-     * @expectedException \Payum\Core\Exception\LogicException
-     * @expectedExceptionMessage The payum.gateway tag require gateway attribute.
-     */
-    public function testThrowIfTagMissFactoryAttribute()
+    public function testThrowIfTagMissFactoryAttribute(): void
     {
+        $this->expectExceptionMessage("The payum.gateway tag require gateway attribute.");
+        $this->expectException(\Payum\Core\Exception\LogicException::class);
         $service = new Definition();
         $service->addTag('payum.gateway');
 

--- a/Tests/DependencyInjection/Compiler/BuildStoragesPassTest.php
+++ b/Tests/DependencyInjection/Compiler/BuildStoragesPassTest.php
@@ -12,14 +12,14 @@ use Symfony\Component\DependencyInjection\Definition;
 
 class BuildStoragesPassTest extends \PHPUnit\Framework\TestCase
 {
-    public function testShouldImplementCompilerPassInterface()
+    public function testShouldImplementCompilerPassInterface(): void
     {
         $rc = new \ReflectionClass(BuildStoragesPass::class);
 
         $this->assertTrue($rc->implementsInterface(CompilerPassInterface::class));
     }
 
-    public function testShouldAddServiceWithTagToStaticRegistry()
+    public function testShouldAddServiceWithTagToStaticRegistry(): void
     {
         $service = new Definition();
         $service->addTag('payum.storage', ['model_class' => stdClass::class]);
@@ -37,12 +37,10 @@ class BuildStoragesPassTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(['stdClass' => 'aservice'], $registry->getArgument(1));
     }
 
-    /**
-     * @expectedException \Payum\Core\Exception\LogicException
-     * @expectedExceptionMessage The payum.storage tag require model_class attribute.
-     */
-    public function testThrowIfTagMissFactoryAttribute()
+    public function testThrowIfTagMissFactoryAttribute(): void
     {
+        $this->expectException(\Payum\Core\Exception\LogicException::class);
+        $this->expectExceptionMessage("The payum.storage tag require model_class attribute.");
         $service = new Definition();
         $service->addTag('payum.storage');
 

--- a/Tests/DependencyInjection/Factory/AbstractStorageFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/AbstractStorageFactoryTest.php
@@ -3,6 +3,7 @@ namespace Payum\Bundle\PayumBundle\Tests\DependencyInjection\Factory;
 
 use Payum\Bundle\PayumBundle\DependencyInjection\Factory\Storage\AbstractStorageFactory;
 use Payum\Bundle\PayumBundle\DependencyInjection\Factory\Storage\StorageFactoryInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -13,7 +14,7 @@ class AbstractStorageFactoryTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function shouldImplementStorageFactoryInterface()
+    public function shouldImplementStorageFactoryInterface(): void
     {
         $rc = new \ReflectionClass('Payum\Bundle\PayumBundle\DependencyInjection\Factory\Storage\AbstractStorageFactory');
         
@@ -23,7 +24,7 @@ class AbstractStorageFactoryTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function shouldBeAbstract()
+    public function shouldBeAbstract(): void
     {
         $rc = new \ReflectionClass(StorageFactoryInterface::class);
 
@@ -33,8 +34,10 @@ class AbstractStorageFactoryTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function shouldAllowAddConfiguration()
+    public function shouldAllowAddConfiguration(): void
     {
+        $this->expectNotToPerformAssertions();
+
         $factory = $this->createAbstractStorageFactory();
 
         $tb = new TreeBuilder('foo');
@@ -49,7 +52,7 @@ class AbstractStorageFactoryTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function shouldAllowCreateStorageAndReturnItsId()
+    public function shouldAllowCreateStorageAndReturnItsId(): void
     {
         $expectedStorage = new Definition();
         
@@ -71,7 +74,7 @@ class AbstractStorageFactoryTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($expectedStorage, $container->getDefinition($actualStorageId));
     }
 
-    protected function assertDefinitionContainsMethodCall(Definition $serviceDefinition, $expectedMethod, $expectedFirstArgument)
+    protected function assertDefinitionContainsMethodCall(Definition $serviceDefinition, $expectedMethod, $expectedFirstArgument): void
     {
         foreach ($serviceDefinition->getMethodCalls() as $methodCall) {
             if ($expectedMethod == $methodCall[0] && $expectedFirstArgument == $methodCall[1][0]) {
@@ -88,7 +91,7 @@ class AbstractStorageFactoryTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|AbstractStorageFactory
+     * @return AbstractStorageFactory|MockObject
      */
     protected function createAbstractStorageFactory()
     {

--- a/Tests/DependencyInjection/Factory/CustomStorageFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/CustomStorageFactoryTest.php
@@ -62,9 +62,6 @@ class CustomStorageFactoryTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @test
-     *
-     *
-     *
      */
     public function shouldRequireServiceOption(): void
     {
@@ -83,9 +80,6 @@ class CustomStorageFactoryTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @test
-     *
-     *
-     *
      */
     public function shouldNotAllowEmptyServiceOption(): void
     {
@@ -106,9 +100,6 @@ class CustomStorageFactoryTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @test
-     *
-     *
-     *
      */
     public function shouldNotAllowNullServiceOption(): void
     {

--- a/Tests/DependencyInjection/Factory/CustomStorageFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/CustomStorageFactoryTest.php
@@ -3,6 +3,7 @@ namespace Payum\Bundle\PayumBundle\Tests\DependencyInjection\Factory;
 
 
 use Payum\Bundle\PayumBundle\DependencyInjection\Factory\Storage\CustomStorageFactory;
+use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -12,7 +13,7 @@ class CustomStorageFactoryTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function shouldBeSubClassOfAbstractStorageFactory()
+    public function shouldBeSubClassOfAbstractStorageFactory(): void
     {
         $rc = new \ReflectionClass('Payum\Bundle\PayumBundle\DependencyInjection\Factory\Storage\CustomStorageFactory');
 
@@ -22,15 +23,16 @@ class CustomStorageFactoryTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function couldBeConstructedWithoutAnyArguments()
+    public function couldBeConstructedWithoutAnyArguments(): void
     {
+        $this->expectNotToPerformAssertions();
         new CustomStorageFactory();
     }
 
     /**
      * @test
      */
-    public function shouldAllowGetName()
+    public function shouldAllowGetName(): void
     {
         $factory = new CustomStorageFactory();
 
@@ -40,7 +42,7 @@ class CustomStorageFactoryTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function shouldAllowAddConfiguration()
+    public function shouldAllowAddConfiguration(): void
     {
         $factory = new CustomStorageFactory();
 
@@ -61,11 +63,13 @@ class CustomStorageFactoryTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      *
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessageRegExp  /The child (node|config) "service" (at path|under) "foo" must be configured\./
+     *
+     *
      */
-    public function shouldRequireServiceOption()
+    public function shouldRequireServiceOption(): void
     {
+        $this->expectExceptionMessageMatches("/The child (node|config) \"service\" (at path|under) \"foo\" must be configured\./");
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
         $factory = new CustomStorageFactory();
 
         $tb = new TreeBuilder('foo');
@@ -80,11 +84,13 @@ class CustomStorageFactoryTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      *
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage The path "foo.service" cannot contain an empty value, but got "".
+     *
+     *
      */
-    public function shouldNotAllowEmptyServiceOption()
+    public function shouldNotAllowEmptyServiceOption(): void
     {
+        $this->expectExceptionMessage("The path \"foo.service\" cannot contain an empty value, but got \"\".");
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
         $factory = new CustomStorageFactory();
 
         $tb = new TreeBuilder('foo');
@@ -101,11 +107,13 @@ class CustomStorageFactoryTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      *
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage The path "foo.service" cannot contain an empty value, but got null.
+     *
+     *
      */
-    public function shouldNotAllowNullServiceOption()
+    public function shouldNotAllowNullServiceOption(): void
     {
+        $this->expectExceptionMessage("The path \"foo.service\" cannot contain an empty value, but got null.");
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
         $factory = new CustomStorageFactory();
 
         $tb = new TreeBuilder('foo');
@@ -122,7 +130,7 @@ class CustomStorageFactoryTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function shouldAllowAddShortConfiguration()
+    public function shouldAllowAddShortConfiguration(): void
     {
         $factory = new CustomStorageFactory;
 
@@ -141,7 +149,7 @@ class CustomStorageFactoryTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function shouldCreateServiceDefinition()
+    public function shouldCreateServiceDefinition(): void
     {
         $serviceName = 'service.name';
 
@@ -155,7 +163,7 @@ class CustomStorageFactoryTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|\Symfony\Component\DependencyInjection\ContainerBuilder
+     * @return MockObject|\Symfony\Component\DependencyInjection\ContainerBuilder
      */
     protected function createContainerBuilderMock()
     {

--- a/Tests/DependencyInjection/Factory/DoctrineStorageFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/DoctrineStorageFactoryTest.php
@@ -78,9 +78,6 @@ class DoctrineStorageFactoryTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @test
-     *
-     *
-     *
      */
     public function shouldRequireDriverOption(): void
     {

--- a/Tests/DependencyInjection/Factory/DoctrineStorageFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/DoctrineStorageFactoryTest.php
@@ -10,7 +10,7 @@ class DoctrineStorageFactoryTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function shouldBeSubClassOfAbstractStorageFactory()
+    public function shouldBeSubClassOfAbstractStorageFactory(): void
     {
         $rc = new \ReflectionClass('Payum\Bundle\PayumBundle\DependencyInjection\Factory\Storage\DoctrineStorageFactory');
 
@@ -20,15 +20,16 @@ class DoctrineStorageFactoryTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function couldBeConstructedWithoutAnyArguments()
+    public function couldBeConstructedWithoutAnyArguments(): void
     {
+        $this->expectNotToPerformAssertions();
         new DoctrineStorageFactory;
     }
 
     /**
      * @test
      */
-    public function shouldAllowGetName()
+    public function shouldAllowGetName(): void
     {
         $factory = new DoctrineStorageFactory;
 
@@ -38,7 +39,7 @@ class DoctrineStorageFactoryTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function shouldAllowAddConfiguration()
+    public function shouldAllowAddConfiguration(): void
     {
         $factory = new DoctrineStorageFactory;
 
@@ -59,7 +60,7 @@ class DoctrineStorageFactoryTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function shouldAllowAddShortConfiguration()
+    public function shouldAllowAddShortConfiguration(): void
     {
         $factory = new DoctrineStorageFactory;
 
@@ -78,11 +79,13 @@ class DoctrineStorageFactoryTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      *
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessageRegExp /The child (node|config) "driver" (at path|under) "foo" must be configured\./
+     *
+     *
      */
-    public function shouldRequireDriverOption()
+    public function shouldRequireDriverOption(): void
     {
+        $this->expectExceptionMessageMatches("/The child (node|config) \"driver\" (at path|under) \"foo\" must be configured\./");
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
         $factory = new DoctrineStorageFactory;
 
         $tb = new TreeBuilder('foo');

--- a/Tests/DependencyInjection/Factory/FilesystemStorageFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/FilesystemStorageFactoryTest.php
@@ -63,9 +63,6 @@ class FilesystemStorageFactoryTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @test
-     *
-     *
-     *
      */
     public function shouldRequireStorageDirOption(): void
     {

--- a/Tests/DependencyInjection/Factory/FilesystemStorageFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/FilesystemStorageFactoryTest.php
@@ -10,7 +10,7 @@ class FilesystemStorageFactoryTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function shouldBeSubClassOfAbstractStorageFactory()
+    public function shouldBeSubClassOfAbstractStorageFactory(): void
     {
         $rc = new \ReflectionClass('Payum\Bundle\PayumBundle\DependencyInjection\Factory\Storage\FilesystemStorageFactory');
 
@@ -20,15 +20,16 @@ class FilesystemStorageFactoryTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function couldBeConstructedWithoutAnyArguments()
+    public function couldBeConstructedWithoutAnyArguments(): void
     {
+        $this->expectNotToPerformAssertions();
         new FilesystemStorageFactory;
     }
 
     /**
      * @test
      */
-    public function shouldAllowGetName()
+    public function shouldAllowGetName(): void
     {
         $factory = new FilesystemStorageFactory;
 
@@ -38,7 +39,7 @@ class FilesystemStorageFactoryTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function shouldAllowAddConfiguration()
+    public function shouldAllowAddConfiguration(): void
     {
         $factory = new FilesystemStorageFactory;
 
@@ -63,11 +64,13 @@ class FilesystemStorageFactoryTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      *
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessageRegExp /The child (node|config) "storage_dir" (at path|under) "foo" must be configured\./
+     *
+     *
      */
-    public function shouldRequireStorageDirOption()
+    public function shouldRequireStorageDirOption(): void
     {
+        $this->expectExceptionMessageMatches("/The child (node|config) \"storage_dir\" (at path|under) \"foo\" must be configured\./");
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
         $factory = new FilesystemStorageFactory;
 
         $tb = new TreeBuilder('foo');
@@ -82,7 +85,7 @@ class FilesystemStorageFactoryTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function shouldSetIdPropertyToNull()
+    public function shouldSetIdPropertyToNull(): void
     {
         $factory = new FilesystemStorageFactory;
 

--- a/Tests/DependencyInjection/Factory/Propel1StorageFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Propel1StorageFactoryTest.php
@@ -11,7 +11,7 @@ class Propel1StorageFactoryTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function shouldBeSubClassOfAbstractStorageFactory()
+    public function shouldBeSubClassOfAbstractStorageFactory(): void
     {
         $rc = new \ReflectionClass('Payum\Bundle\PayumBundle\DependencyInjection\Factory\Storage\Propel1StorageFactory');
         
@@ -21,15 +21,16 @@ class Propel1StorageFactoryTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function couldBeConstructedWithoutAnyArguments()
+    public function couldBeConstructedWithoutAnyArguments(): void
     {
+        $this->expectNotToPerformAssertions();
         new Propel1StorageFactory;
     }
     
     /**
      * @test
      */
-    public function shouldAllowGetName()
+    public function shouldAllowGetName(): void
     {
         $factory = new Propel1StorageFactory;
 

--- a/Tests/DependencyInjection/Factory/Propel2StorageFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Propel2StorageFactoryTest.php
@@ -12,7 +12,7 @@ class Propel2StorageFactoryTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function shouldBeSubClassOfAbstractStorageFactory()
+    public function shouldBeSubClassOfAbstractStorageFactory(): void
     {
         $rc = new \ReflectionClass('Payum\Bundle\PayumBundle\DependencyInjection\Factory\Storage\Propel2StorageFactory');
 
@@ -22,15 +22,16 @@ class Propel2StorageFactoryTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function couldBeConstructedWithoutAnyArguments()
+    public function couldBeConstructedWithoutAnyArguments(): void
     {
+        $this->expectNotToPerformAssertions();
         new Propel2StorageFactory;
     }
 
     /**
      * @test
      */
-    public function shouldAllowGetName()
+    public function shouldAllowGetName(): void
     {
         $factory = new Propel2StorageFactory;
 

--- a/Tests/DependencyInjection/MainConfigurationTest.php
+++ b/Tests/DependencyInjection/MainConfigurationTest.php
@@ -245,9 +245,6 @@ class MainConfigurationTest extends TestCase
 
     /**
      * @test
-     *
-     *
-     *
      */
     public function throwIfTryToUseNotValidClassAsStorageEntry(): void
     {
@@ -281,9 +278,6 @@ class MainConfigurationTest extends TestCase
 
     /**
      * @test
-     *
-     *
-     *
      */
     public function throwIfTryToAddMoreThenOneStorageForOneEntry(): void
     {
@@ -320,9 +314,6 @@ class MainConfigurationTest extends TestCase
 
     /**
      * @test
-     *
-     *
-     *
      */
     public function throwIfStorageEntryDefinedWithoutConcreteStorage(): void
     {
@@ -381,9 +372,6 @@ class MainConfigurationTest extends TestCase
 
     /**
      * @test
-     *
-     *
-     *
      */
     public function throwIfMoreThenOneTokenStorageConfigured(): void
     {
@@ -415,9 +403,6 @@ class MainConfigurationTest extends TestCase
 
     /**
      * @test
-     *
-     *
-     *
      */
     public function throwIfTokenStorageConfiguredWithModelNotImplementingTokenInterface(): void
     {
@@ -444,9 +429,6 @@ class MainConfigurationTest extends TestCase
 
     /**
      * @test
-     *
-     *
-     *
      */
     public function throwIfTokenStorageConfiguredWithNotModelClass(): void
     {
@@ -473,9 +455,6 @@ class MainConfigurationTest extends TestCase
 
     /**
      * @test
-     *
-     *
-     *
      */
     public function throwIfSecurityNotConfigured(): void
     {
@@ -492,9 +471,6 @@ class MainConfigurationTest extends TestCase
 
     /**
      * @test
-     *
-     *
-     *
      */
     public function throwIfTokenStorageNotConfigured(): void
     {
@@ -513,9 +489,6 @@ class MainConfigurationTest extends TestCase
 
     /**
      * @test
-     *
-     *
-     *
      */
     public function throwIfMoreThenOneGatewayConfigStorageConfigured(): void
     {
@@ -556,9 +529,6 @@ class MainConfigurationTest extends TestCase
 
     /**
      * @test
-     *
-     *
-     *
      */
     public function throwIfGatewayConfigStorageConfiguredWithModelNotImplementingGatewayConfigInterface(): void
     {
@@ -594,9 +564,6 @@ class MainConfigurationTest extends TestCase
 
     /**
      * @test
-     *
-     *
-     *
      */
     public function throwIfGatewayConfigStorageConfiguredWithNotModelClass(): void
     {
@@ -632,9 +599,6 @@ class MainConfigurationTest extends TestCase
 
     /**
      * @test
-     *
-     *
-     *
      */
     public function throwIfGatewayConfigStorageNotConfigured(): void
     {
@@ -746,17 +710,17 @@ class MainConfigurationTest extends TestCase
 
 class FooStorageFactory implements StorageFactoryInterface
 {
-    public function create(ContainerBuilder $container, string $modelClass, array $config): string
+    public function create(ContainerBuilder $container, $modelClass, array $config)
     {
-        return 'serviceId';
+        return 'aStorageId';
     }
 
-    public function getName(): string
+    public function getName()
     {
         return 'foo_storage';
     }
 
-    public function addConfiguration(ArrayNodeDefinition $builder): void
+    public function addConfiguration(ArrayNodeDefinition $builder)
     {
         $builder
             ->children()
@@ -768,17 +732,17 @@ class FooStorageFactory implements StorageFactoryInterface
 
 class BarStorageFactory implements StorageFactoryInterface
 {
-    public function create(ContainerBuilder $container, string $modelClass, array $config): string
+    public function create(ContainerBuilder $container, $modelClass, array $config)
     {
         return 'serviceId';
     }
 
-    public function getName(): string
+    public function getName()
     {
         return 'bar_storage';
     }
 
-    public function addConfiguration(ArrayNodeDefinition $builder): void
+    public function addConfiguration(ArrayNodeDefinition $builder)
     {
         $builder
             ->children()

--- a/Tests/DependencyInjection/MainConfigurationTest.php
+++ b/Tests/DependencyInjection/MainConfigurationTest.php
@@ -10,7 +10,7 @@ use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 
 class MainConfigurationTest extends TestCase
 {
-    protected $storageFactories = array();
+    protected array $storageFactories = [];
 
     protected function setUp(): void
     {
@@ -23,16 +23,19 @@ class MainConfigurationTest extends TestCase
     /**
      * @test
      */
-    public function couldBeConstructedWithArrayOfGatewayFactoriesAndStorageFactories()
+    public function couldBeConstructedWithArrayOfGatewayFactoriesAndStorageFactories(): void
     {
+        $this->expectNotToPerformAssertions();
         new MainConfiguration($this->storageFactories);
     }
 
     /**
      * @test
      */
-    public function shouldPassConfigurationProcessing()
+    public function shouldPassConfigurationProcessing(): void
     {
+        $this->expectNotToPerformAssertions();
+
         $configuration = new MainConfiguration($this->storageFactories);
 
         $processor = new Processor();
@@ -80,7 +83,7 @@ class MainConfigurationTest extends TestCase
     /**
      * @test
      */
-    public function shouldAddStoragesToAllGatewayByDefault()
+    public function shouldAddStoragesToAllGatewayByDefault(): void
     {
         $configuration = new MainConfiguration($this->storageFactories);
 
@@ -122,7 +125,7 @@ class MainConfigurationTest extends TestCase
     /**
      * @test
      */
-    public function shouldAllowDisableAddStoragesToAllGatewayFeature()
+    public function shouldAllowDisableAddStoragesToAllGatewayFeature(): void
     {
         $configuration = new MainConfiguration($this->storageFactories);
 
@@ -161,7 +164,7 @@ class MainConfigurationTest extends TestCase
     /**
      * @test
      */
-    public function shouldAllowSetConcreteGatewaysWhereToAddStorages()
+    public function shouldAllowSetConcreteGatewaysWhereToAddStorages(): void
     {
         $configuration = new MainConfiguration($this->storageFactories);
 
@@ -202,7 +205,7 @@ class MainConfigurationTest extends TestCase
     /**
      * @test
      */
-    public function shouldAllowSetGatewaysCreatedWithFactoriesWhereToAddStorages()
+    public function shouldAllowSetGatewaysCreatedWithFactoriesWhereToAddStorages(): void
     {
         $configuration = new MainConfiguration($this->storageFactories);
 
@@ -243,11 +246,13 @@ class MainConfigurationTest extends TestCase
     /**
      * @test
      *
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage Invalid configuration for path "payum.storages": The storage entry must be a valid model class. It is set notExistClass
+     *
+     *
      */
-    public function throwIfTryToUseNotValidClassAsStorageEntry()
+    public function throwIfTryToUseNotValidClassAsStorageEntry(): void
     {
+        $this->expectExceptionMessage("Invalid configuration for path \"payum.storages\": The storage entry must be a valid model class. It is set notExistClass");
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
         $configuration = new MainConfiguration($this->storageFactories);
 
         $processor = new Processor();
@@ -277,11 +282,13 @@ class MainConfigurationTest extends TestCase
     /**
      * @test
      *
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage Invalid configuration for path "payum.storages.stdClass": Only one storage per entry could be selected
+     *
+     *
      */
-    public function throwIfTryToAddMoreThenOneStorageForOneEntry()
+    public function throwIfTryToAddMoreThenOneStorageForOneEntry(): void
     {
+        $this->expectExceptionMessage("Invalid configuration for path \"payum.storages.stdClass\": Only one storage per entry could be selected");
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
         $configuration = new MainConfiguration($this->storageFactories);
 
         $processor = new Processor();
@@ -314,11 +321,13 @@ class MainConfigurationTest extends TestCase
     /**
      * @test
      *
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage Invalid configuration for path "payum.storages.stdClass": At least one storage must be configured.
+     *
+     *
      */
-    public function throwIfStorageEntryDefinedWithoutConcreteStorage()
+    public function throwIfStorageEntryDefinedWithoutConcreteStorage(): void
     {
+        $this->expectExceptionMessage("Invalid configuration for path \"payum.storages.stdClass\": At least one storage must be configured.");
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
         $configuration = new MainConfiguration($this->storageFactories);
 
         $processor = new Processor();
@@ -344,8 +353,10 @@ class MainConfigurationTest extends TestCase
     /**
      * @test
      */
-    public function shouldPassIfNoneStorageSelected()
+    public function shouldPassIfNoneStorageSelected(): void
     {
+        $this->expectNotToPerformAssertions();
+
         $configuration = new MainConfiguration($this->storageFactories);
 
         $processor = new Processor();
@@ -371,11 +382,13 @@ class MainConfigurationTest extends TestCase
     /**
      * @test
      *
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage Invalid configuration for path "payum.security.token_storage": Only one token storage could be configured.
+     *
+     *
      */
-    public function throwIfMoreThenOneTokenStorageConfigured()
+    public function throwIfMoreThenOneTokenStorageConfigured(): void
     {
+        $this->expectExceptionMessage("Invalid configuration for path \"payum.security.token_storage\": Only one token storage could be configured.");
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
         $configuration = new MainConfiguration($this->storageFactories);
 
         $processor = new Processor();
@@ -403,11 +416,13 @@ class MainConfigurationTest extends TestCase
     /**
      * @test
      *
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage Invalid configuration for path "payum.security.token_storage": The token class must implement `Payum\Core\Security\TokenInterface` interface
+     *
+     *
      */
-    public function throwIfTokenStorageConfiguredWithModelNotImplementingTokenInterface()
+    public function throwIfTokenStorageConfiguredWithModelNotImplementingTokenInterface(): void
     {
+        $this->expectExceptionMessage("Invalid configuration for path \"payum.security.token_storage\": The token class must implement `Payum\Core\Security\TokenInterface` interface");
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
         $configuration = new MainConfiguration($this->storageFactories);
 
         $processor = new Processor();
@@ -430,11 +445,13 @@ class MainConfigurationTest extends TestCase
     /**
      * @test
      *
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage Invalid configuration for path "payum.security.token_storage": The storage entry must be a valid model class.
+     *
+     *
      */
-    public function throwIfTokenStorageConfiguredWithNotModelClass()
+    public function throwIfTokenStorageConfiguredWithNotModelClass(): void
     {
+        $this->expectExceptionMessage("Invalid configuration for path \"payum.security.token_storage\": The storage entry must be a valid model class.");
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
         $configuration = new MainConfiguration($this->storageFactories);
 
         $processor = new Processor();
@@ -457,11 +474,13 @@ class MainConfigurationTest extends TestCase
     /**
      * @test
      *
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessageRegExp /The child (node|config) "security" (at path|under) "payum" must be configured\./
+     *
+     *
      */
-    public function throwIfSecurityNotConfigured()
+    public function throwIfSecurityNotConfigured(): void
     {
+        $this->expectExceptionMessageMatches("/The child (node|config) \"security\" (at path|under) \"payum\" must be configured\./");
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
         $configuration = new MainConfiguration($this->storageFactories);
 
         $processor = new Processor();
@@ -474,11 +493,13 @@ class MainConfigurationTest extends TestCase
     /**
      * @test
      *
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessageRegExp /The child (node|config) "token_storage" (at path|under) "payum.security" must be configured\./
+     *
+     *
      */
-    public function throwIfTokenStorageNotConfigured()
+    public function throwIfTokenStorageNotConfigured(): void
     {
+        $this->expectExceptionMessageMatches("/The child (node|config) \"token_storage\" (at path|under) \"payum.security\" must be configured\./");
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
         $configuration = new MainConfiguration($this->storageFactories);
 
         $processor = new Processor();
@@ -493,11 +514,13 @@ class MainConfigurationTest extends TestCase
     /**
      * @test
      *
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage Invalid configuration for path "payum.dynamic_gateways.config_storage": Only one config storage could be configured.
+     *
+     *
      */
-    public function throwIfMoreThenOneGatewayConfigStorageConfigured()
+    public function throwIfMoreThenOneGatewayConfigStorageConfigured(): void
     {
+        $this->expectExceptionMessage("Invalid configuration for path \"payum.dynamic_gateways.config_storage\": Only one config storage could be configured.");
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
         $configuration = new MainConfiguration($this->storageFactories);
 
         $processor = new Processor();
@@ -534,11 +557,13 @@ class MainConfigurationTest extends TestCase
     /**
      * @test
      *
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage Invalid configuration for path "payum.dynamic_gateways.config_storage": The config class must implement `Payum\Core\Model\GatewayConfigInterface` interface
+     *
+     *
      */
-    public function throwIfGatewayConfigStorageConfiguredWithModelNotImplementingGatewayConfigInterface()
+    public function throwIfGatewayConfigStorageConfiguredWithModelNotImplementingGatewayConfigInterface(): void
     {
+        $this->expectExceptionMessage("Invalid configuration for path \"payum.dynamic_gateways.config_storage\": The config class must implement `Payum\Core\Model\GatewayConfigInterface` interface");
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
         $configuration = new MainConfiguration($this->storageFactories);
 
         $processor = new Processor();
@@ -570,11 +595,13 @@ class MainConfigurationTest extends TestCase
     /**
      * @test
      *
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage Invalid configuration for path "payum.dynamic_gateways.config_storage": The storage entry must be a valid model class.
+     *
+     *
      */
-    public function throwIfGatewayConfigStorageConfiguredWithNotModelClass()
+    public function throwIfGatewayConfigStorageConfiguredWithNotModelClass(): void
     {
+        $this->expectExceptionMessage("Invalid configuration for path \"payum.dynamic_gateways.config_storage\": The storage entry must be a valid model class.");
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
         $configuration = new MainConfiguration($this->storageFactories);
 
         $processor = new Processor();
@@ -606,11 +633,13 @@ class MainConfigurationTest extends TestCase
     /**
      * @test
      *
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessageRegExp /The child (node|config) "config_storage" (at path|under) "payum.dynamic_gateways" must be configured\./
+     *
+     *
      */
-    public function throwIfGatewayConfigStorageNotConfigured()
+    public function throwIfGatewayConfigStorageNotConfigured(): void
     {
+        $this->expectExceptionMessageMatches("/The child (node|config) \"config_storage\" (at path|under) \"payum.dynamic_gateways\" must be configured\./");
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
         $configuration = new MainConfiguration($this->storageFactories);
 
         $processor = new Processor();
@@ -635,7 +664,7 @@ class MainConfigurationTest extends TestCase
     /**
      * @test
      */
-    public function shouldTreatNullGatewaysV2AsEmptyArray()
+    public function shouldTreatNullGatewaysV2AsEmptyArray(): void
     {
         $configuration = new MainConfiguration($this->storageFactories);
 
@@ -662,7 +691,7 @@ class MainConfigurationTest extends TestCase
     /**
      * @test
      */
-    public function shouldAllowPutAnythingToGatewaysV2AndNotPerformAnyValidations()
+    public function shouldAllowPutAnythingToGatewaysV2AndNotPerformAnyValidations(): void
     {
         $configuration = new MainConfiguration($this->storageFactories);
 
@@ -717,16 +746,17 @@ class MainConfigurationTest extends TestCase
 
 class FooStorageFactory implements StorageFactoryInterface
 {
-    public function create(ContainerBuilder $container, $modelClass, array $config)
+    public function create(ContainerBuilder $container, string $modelClass, array $config): string
     {
+        return 'serviceId';
     }
 
-    public function getName()
+    public function getName(): string
     {
         return 'foo_storage';
     }
 
-    public function addConfiguration(ArrayNodeDefinition $builder)
+    public function addConfiguration(ArrayNodeDefinition $builder): void
     {
         $builder
             ->children()
@@ -738,16 +768,17 @@ class FooStorageFactory implements StorageFactoryInterface
 
 class BarStorageFactory implements StorageFactoryInterface
 {
-    public function create(ContainerBuilder $container, $modelClass, array $config)
+    public function create(ContainerBuilder $container, string $modelClass, array $config): string
     {
+        return 'serviceId';
     }
 
-    public function getName()
+    public function getName(): string
     {
         return 'bar_storage';
     }
 
-    public function addConfiguration(ArrayNodeDefinition $builder)
+    public function addConfiguration(ArrayNodeDefinition $builder): void
     {
         $builder
             ->children()

--- a/Tests/DependencyInjection/PayumExtensionTest.php
+++ b/Tests/DependencyInjection/PayumExtensionTest.php
@@ -14,7 +14,7 @@ class PayumExtensionTest extends TestCase
     /**
      * @test
      */
-    public function shouldBeSubClassOfExtension()
+    public function shouldBeSubClassOfExtension(): void
     {
         $rc = new \ReflectionClass(PayumExtension::class);
 
@@ -24,7 +24,7 @@ class PayumExtensionTest extends TestCase
     /**
      * @test
      */
-    public function shouldImplementPrependExtensionInterface()
+    public function shouldImplementPrependExtensionInterface(): void
     {
         $rc = new \ReflectionClass(PayumExtension::class);
 
@@ -34,15 +34,16 @@ class PayumExtensionTest extends TestCase
     /**
      * @test
      */
-    public function couldBeConstructedWithoutAnyArguments()
+    public function couldBeConstructedWithoutAnyArguments(): void
     {
+        $this->expectNotToPerformAssertions();
         new PayumExtension;
     }
 
     /**
      * @test
      */
-    public function shouldAllowAddStorageFactory()
+    public function shouldAllowAddStorageFactory(): void
     {
         $factory = $this->createMock(StorageFactoryInterface::class);
         $factory
@@ -54,17 +55,23 @@ class PayumExtensionTest extends TestCase
         $extension = new PayumExtension;
         $extension->addStorageFactory($factory);
 
+        $this->markTestIncomplete(
+            'Replacement for PhpUnit9 needed.'
+        );
+
         $this->assertAttributeContains($factory, 'storagesFactories', $extension);
     }
 
     /**
      * @test
      *
-     * @expectedException \Payum\Core\Exception\InvalidArgumentException
-     * @expectedExceptionMessage The storage factory Mock_StorageFactoryInterface_
+     *
+     *
      */
-    public function throwIfTryToAddStorageFactoryWithEmptyName()
+    public function throwIfTryToAddStorageFactoryWithEmptyName(): void
     {
+        $this->expectExceptionMessage("The storage factory Mock_StorageFactoryInterface_");
+        $this->expectException(\Payum\Core\Exception\InvalidArgumentException::class);
         $factoryWithEmptyName = $this->createMock(StorageFactoryInterface::class);
         $factoryWithEmptyName
             ->expects($this->once())
@@ -79,11 +86,13 @@ class PayumExtensionTest extends TestCase
     /**
      * @test
      *
-     * @expectedException \Payum\Core\Exception\InvalidArgumentException
-     * @expectedExceptionMessage The storage factory with such name theFoo already registered
+     *
+     *
      */
-    public function throwIfTryToAddStorageGatewayFactoryWithNameAlreadyAdded()
+    public function throwIfTryToAddStorageGatewayFactoryWithNameAlreadyAdded(): void
     {
+        $this->expectExceptionMessage("The storage factory with such name theFoo already registered");
+        $this->expectException(\Payum\Core\Exception\InvalidArgumentException::class);
         $factory = $this->createMock(StorageFactoryInterface::class);
         $factory
             ->expects($this->atLeastOnce())
@@ -99,7 +108,7 @@ class PayumExtensionTest extends TestCase
     /**
      * @test
      */
-    public function shouldNotAddPayumMappingIfDoctrineBundleNotRegistered()
+    public function shouldNotAddPayumMappingIfDoctrineBundleNotRegistered(): void
     {
         $container = new ContainerBuilder;
         $container->setParameter('kernel.bundles', array());
@@ -114,7 +123,7 @@ class PayumExtensionTest extends TestCase
     /**
      * @test
      */
-    public function shouldNotAddPayumMappingIfDoctrineBundleRegisteredButDbalNotConfigured()
+    public function shouldNotAddPayumMappingIfDoctrineBundleRegisteredButDbalNotConfigured(): void
     {
         $extension = new PayumExtension;
 
@@ -137,7 +146,7 @@ class PayumExtensionTest extends TestCase
     /**
      * @test
      */
-    public function shouldNotAddPayumMappingIfDoctrineBundleRegisteredButOrmNotConfigured()
+    public function shouldNotAddPayumMappingIfDoctrineBundleRegisteredButOrmNotConfigured(): void
     {
         $extension = new PayumExtension;
 
@@ -160,7 +169,7 @@ class PayumExtensionTest extends TestCase
     /**
      * @test
      */
-    public function shouldAddPayumMappingIfDoctrineBundleRegisteredWithDbalAndOrmConfiguredInSingleConfiguration()
+    public function shouldAddPayumMappingIfDoctrineBundleRegisteredWithDbalAndOrmConfiguredInSingleConfiguration(): void
     {
         $extension = new PayumExtension;
 
@@ -201,7 +210,7 @@ class PayumExtensionTest extends TestCase
     /**
      * @test
      */
-    public function shouldAddPayumMappingIfDoctrineBundleRegisteredWithDbalAndOrmConfiguredInMultipleConfigurations()
+    public function shouldAddPayumMappingIfDoctrineBundleRegisteredWithDbalAndOrmConfiguredInMultipleConfigurations(): void
     {
         $extension = new PayumExtension;
 
@@ -246,7 +255,7 @@ class PayumExtensionTest extends TestCase
     /**
      * @test
      */
-    public function shouldAddGatewaysToBuilder()
+    public function shouldAddGatewaysToBuilder(): void
     {
         $extension = new PayumExtension;
         $extension->addStorageFactory(new FeeStorageFactory());
@@ -295,17 +304,17 @@ class PayumExtensionTest extends TestCase
 
 class FeeStorageFactory implements StorageFactoryInterface
 {
-    public function create(ContainerBuilder $container, $modelClass, array $config)
+    public function create(ContainerBuilder $container, string $modelClass, array $config): string
     {
         return 'aStorageId';
     }
 
-    public function getName()
+    public function getName(): string
     {
         return 'bar_storage';
     }
 
-    public function addConfiguration(ArrayNodeDefinition $builder)
+    public function addConfiguration(ArrayNodeDefinition $builder): void
     {
         $builder
             ->children()

--- a/Tests/DependencyInjection/PayumExtensionTest.php
+++ b/Tests/DependencyInjection/PayumExtensionTest.php
@@ -55,11 +55,11 @@ class PayumExtensionTest extends TestCase
         $extension = new PayumExtension;
         $extension->addStorageFactory($factory);
 
-        $this->markTestIncomplete(
-            'Replacement for PhpUnit9 needed.'
-        );
+        $reflected_constraint = (new \ReflectionObject($extension))->getProperty('storagesFactories');
+        $reflected_constraint->setAccessible(TRUE);
+        $constraint = $reflected_constraint->getValue($extension);
 
-        $this->assertAttributeContains($factory, 'storagesFactories', $extension);
+        $this->assertEquals($factory, $constraint["theFoo"]);
     }
 
     /**

--- a/Tests/DependencyInjection/PayumExtensionTest.php
+++ b/Tests/DependencyInjection/PayumExtensionTest.php
@@ -55,8 +55,8 @@ class PayumExtensionTest extends TestCase
         $extension->addStorageFactory($factory);
 
         $reflectedConstraint = (new \ReflectionObject($extension))->getProperty('storagesFactories');
-        $reflected_constraint->setAccessible(true);
-        $constraint = $reflected_constraint->getValue($extension);
+        $reflectedConstraint->setAccessible(true);
+        $constraint = $reflectedConstraint->getValue($extension);
 
         $this->assertEquals($factory, $constraint["theFoo"]);
     }

--- a/Tests/DependencyInjection/PayumExtensionTest.php
+++ b/Tests/DependencyInjection/PayumExtensionTest.php
@@ -47,9 +47,8 @@ class PayumExtensionTest extends TestCase
     {
         $factory = $this->createMock(StorageFactoryInterface::class);
         $factory
-            ->expects($this->any())
             ->method('getName')
-            ->will($this->returnValue('theFoo'))
+            ->willReturn('theFoo')
         ;
 
         $extension = new PayumExtension;
@@ -73,7 +72,7 @@ class PayumExtensionTest extends TestCase
         $factoryWithEmptyName
             ->expects($this->once())
             ->method('getName')
-            ->will($this->returnValue(''))
+            ->willReturn('')
         ;
 
         $extension = new PayumExtension;
@@ -91,7 +90,7 @@ class PayumExtensionTest extends TestCase
         $factory
             ->expects($this->atLeastOnce())
             ->method('getName')
-            ->will($this->returnValue('theFoo'))
+            ->willReturn('theFoo')
         ;
 
         $extension = new PayumExtension;

--- a/Tests/DependencyInjection/PayumExtensionTest.php
+++ b/Tests/DependencyInjection/PayumExtensionTest.php
@@ -64,9 +64,6 @@ class PayumExtensionTest extends TestCase
 
     /**
      * @test
-     *
-     *
-     *
      */
     public function throwIfTryToAddStorageFactoryWithEmptyName(): void
     {
@@ -85,9 +82,6 @@ class PayumExtensionTest extends TestCase
 
     /**
      * @test
-     *
-     *
-     *
      */
     public function throwIfTryToAddStorageGatewayFactoryWithNameAlreadyAdded(): void
     {
@@ -304,7 +298,7 @@ class PayumExtensionTest extends TestCase
 
 class FeeStorageFactory implements StorageFactoryInterface
 {
-    public function create(ContainerBuilder $container, string $modelClass, array $config): string
+    public function create(ContainerBuilder $container, $modelClass, array $config)
     {
         return 'aStorageId';
     }

--- a/Tests/DependencyInjection/PayumExtensionTest.php
+++ b/Tests/DependencyInjection/PayumExtensionTest.php
@@ -55,7 +55,7 @@ class PayumExtensionTest extends TestCase
         $extension->addStorageFactory($factory);
 
         $reflected_constraint = (new \ReflectionObject($extension))->getProperty('storagesFactories');
-        $reflected_constraint->setAccessible(TRUE);
+        $reflected_constraint->setAccessible(true);
         $constraint = $reflected_constraint->getValue($extension);
 
         $this->assertEquals($factory, $constraint["theFoo"]);

--- a/Tests/DependencyInjection/PayumExtensionTest.php
+++ b/Tests/DependencyInjection/PayumExtensionTest.php
@@ -54,7 +54,7 @@ class PayumExtensionTest extends TestCase
         $extension = new PayumExtension;
         $extension->addStorageFactory($factory);
 
-        $reflected_constraint = (new \ReflectionObject($extension))->getProperty('storagesFactories');
+        $reflectedConstraint = (new \ReflectionObject($extension))->getProperty('storagesFactories');
         $reflected_constraint->setAccessible(true);
         $constraint = $reflected_constraint->getValue($extension);
 

--- a/Tests/EventListener/ReplyToHttpResponseListenerTest.php
+++ b/Tests/EventListener/ReplyToHttpResponseListenerTest.php
@@ -4,6 +4,8 @@ namespace Payum\Bundle\PayumBundle\Tests\EventListener;
 use Payum\Bundle\PayumBundle\EventListener\ReplyToHttpResponseListener;
 use Payum\Core\Bridge\Symfony\ReplyToSymfonyResponseConverter;
 use Payum\Core\Reply\HttpRedirect;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Exception\Exception;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -11,20 +13,21 @@ use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Kernel;
 
-class ReplyToHttpResponseListenerTest extends \PHPUnit\Framework\TestCase
+class ReplyToHttpResponseListenerTest extends TestCase
 {
     /**
      * @test
      */
-    public function couldBeConstructedWithOneArgument()
+    public function couldBeConstructedWithOneArgument(): void
     {
+        $this->expectNotToPerformAssertions();
         new ReplyToHttpResponseListener($this->createReplyToSymfonyResponseConverterMock());
     }
 
     /**
      * @test
      */
-    public function shouldDoNothingIfExceptionNotInstanceOfReply()
+    public function shouldDoNothingIfExceptionNotInstanceOfReply(): void
     {
         $expectedException = new Exception;
 
@@ -53,7 +56,7 @@ class ReplyToHttpResponseListenerTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function shouldSetResponseReturnedByConverterToEvent()
+    public function shouldSetResponseReturnedByConverterToEvent(): void
     {
         $expectedUrl = '/foo/bar';
 
@@ -86,7 +89,7 @@ class ReplyToHttpResponseListenerTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function shouldCallAllowCustomResponseCode()
+    public function shouldCallAllowCustomResponseCode(): void
     {
         $reply = new HttpRedirect('/foo/bar');
         $response = new Response('', 302);
@@ -111,7 +114,7 @@ class ReplyToHttpResponseListenerTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|ReplyToSymfonyResponseConverter
+     * @return MockObject|ReplyToSymfonyResponseConverter
      */
     protected function createReplyToSymfonyResponseConverterMock()
     {
@@ -119,7 +122,7 @@ class ReplyToHttpResponseListenerTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|HttpKernelInterface
+     * @return HttpKernelInterface|MockObject
      */
     protected function createHttpKernelMock()
     {

--- a/Tests/Functional/Command/CreateCaptureTokenCommandTest.php
+++ b/Tests/Functional/Command/CreateCaptureTokenCommandTest.php
@@ -14,7 +14,7 @@ class CreateCaptureTokenCommandTest extends WebTestCase
     /**
      * @test
      */
-    public function shouldCreateCaptureTokenWithUrlAsAfterUrl()
+    public function shouldCreateCaptureTokenWithUrlAsAfterUrl(): void
     {
         /** @var RegistryInterface $payum */
         $payum = $this->client->getContainer()->get('payum');
@@ -34,16 +34,16 @@ class CreateCaptureTokenCommandTest extends WebTestCase
             '--after-url' => 'http://google.com/'
         ));
 
-        $this->assertContains('Hash: ', $output);
-        $this->assertContains('Url: http://localhost/payment/capture', $output);
-        $this->assertContains('After Url: http://google.com/?payum_token=', $output);
-        $this->assertContains("Details: $modelClass#$modelId", $output);
+        $this->assertStringContainsString('Hash: ', $output);
+        $this->assertStringContainsString('Url: http://localhost/payment/capture', $output);
+        $this->assertStringContainsString('After Url: http://google.com/?payum_token=', $output);
+        $this->assertStringContainsString("Details: $modelClass#$modelId", $output);
     }
 
     /**
      * @test
      */
-    public function shouldCreateCaptureTokenWithRouteAsAfterUrl()
+    public function shouldCreateCaptureTokenWithRouteAsAfterUrl(): void
     {
         /** @var RegistryInterface $payum */
         $payum = $this->client->getContainer()->get('payum');
@@ -63,19 +63,16 @@ class CreateCaptureTokenCommandTest extends WebTestCase
             '--after-url' => 'foo'
         ));
 
-        $this->assertContains('Hash: ', $output);
-        $this->assertContains('Url: http://localhost/payment/capture', $output);
-        $this->assertContains('After Url: http://localhost/foo/url?payum_token=', $output);
-        $this->assertContains("Details: $modelClass#$modelId", $output);
+        $this->assertStringContainsString('Hash: ', $output);
+        $this->assertStringContainsString('Url: http://localhost/payment/capture', $output);
+        $this->assertStringContainsString('After Url: http://localhost/foo/url?payum_token=', $output);
+        $this->assertStringContainsString("Details: $modelClass#$modelId", $output);
     }
 
     /**
-     * @param Command  $command
      * @param string[] $arguments
-     *
-     * @return string
      */
-    protected function executeConsole(Command $command, array $arguments = array())
+    protected function executeConsole(Command $command, array $arguments = array()): string
     {
         $command->setApplication(new Application($this->client->getKernel()));
         if ($command instanceof ContainerAwareInterface) {

--- a/Tests/Functional/Command/CreateNotifyTokenCommandTest.php
+++ b/Tests/Functional/Command/CreateNotifyTokenCommandTest.php
@@ -14,21 +14,21 @@ class CreateNotifyTokenCommandTest extends WebTestCase
     /**
      * @test
      */
-    public function shouldCreateNotifyTokenWithoutModel()
+    public function shouldCreateNotifyTokenWithoutModel(): void
     {
         $output = $this->executeConsole(new CreateNotifyTokenCommand, array(
             'gateway-name' => 'fooGateway'
         ));
 
-        $this->assertContains('Hash: ', $output);
-        $this->assertContains('Url: ', $output);
-        $this->assertContains('Details: null', $output);
+        $this->assertStringContainsString('Hash: ', $output);
+        $this->assertStringContainsString('Url: ', $output);
+        $this->assertStringContainsString('Details: null', $output);
     }
 
     /**
      * @test
      */
-    public function shouldCreateNotifyTokenWithModel()
+    public function shouldCreateNotifyTokenWithModel(): void
     {
         /** @var RegistryInterface $payum */
         $payum = $this->client->getContainer()->get('payum');
@@ -47,18 +47,15 @@ class CreateNotifyTokenCommandTest extends WebTestCase
             '--model-id' => $modelId
         ));
 
-        $this->assertContains('Hash: ', $output);
-        $this->assertContains('Url: ', $output);
-        $this->assertContains("Details: $modelClass#$modelId", $output);
+        $this->assertStringContainsString('Hash: ', $output);
+        $this->assertStringContainsString('Url: ', $output);
+        $this->assertStringContainsString("Details: $modelClass#$modelId", $output);
     }
 
     /**
-     * @param Command  $command
      * @param string[] $arguments
-     *
-     * @return string
      */
-    protected function executeConsole(Command $command, array $arguments = array())
+    protected function executeConsole(Command $command, array $arguments = array()): string
     {
         $command->setApplication(new Application($this->client->getKernel()));
         if ($command instanceof ContainerAwareInterface) {

--- a/Tests/Functional/Command/DebugGatewayCommandTest.php
+++ b/Tests/Functional/Command/DebugGatewayCommandTest.php
@@ -13,58 +13,58 @@ class DebugGatewayCommandTest extends WebTestCase
     /**
      * @test
      */
-    public function shouldOutputDebugInfoAboutSingleGateway()
+    public function shouldOutputDebugInfoAboutSingleGateway(): void
     {
         $output = $this->executeConsole(new DebugGatewayCommand(), array(
             'gateway-name' => 'fooGateway',
         ));
 
-        $this->assertContains('Found 1 gateways', $output);
-        $this->assertContains('fooGateway (Payum\Core\Gateway):', $output);
-        $this->assertContains('Actions:', $output);
-        $this->assertContains('Extensions:', $output);
-        $this->assertContains('Apis:', $output);
+        $this->assertStringContainsString('Found 1 gateways', $output);
+        $this->assertStringContainsString('fooGateway (Payum\Core\Gateway):', $output);
+        $this->assertStringContainsString('Actions:', $output);
+        $this->assertStringContainsString('Extensions:', $output);
+        $this->assertStringContainsString('Apis:', $output);
 
-        $this->assertContains('Payum\Offline\Action\CaptureAction', $output);
+        $this->assertStringContainsString('Payum\Offline\Action\CaptureAction', $output);
 
-        $this->assertContains('Payum\Core\Extension\StorageExtension', $output);
-        $this->assertContains('Payum\Core\Storage\FilesystemStorage', $output);
-        $this->assertContains('Payum\Core\Model\ArrayObject', $output);
+        $this->assertStringContainsString('Payum\Core\Extension\StorageExtension', $output);
+        $this->assertStringContainsString('Payum\Core\Storage\FilesystemStorage', $output);
+        $this->assertStringContainsString('Payum\Core\Model\ArrayObject', $output);
     }
 
     /**
      * @test
      */
-    public function shouldOutputDebugInfoAboutAllGateways()
+    public function shouldOutputDebugInfoAboutAllGateways(): void
     {
         $output = $this->executeConsole(new DebugGatewayCommand());
 
-        $this->assertContains('Found 2 gateways', $output);
-        $this->assertContains('fooGateway (Payum\Core\Gateway):', $output);
-        $this->assertContains('barGateway (Payum\Core\Gateway):', $output);
+        $this->assertStringContainsString('Found 2 gateways', $output);
+        $this->assertStringContainsString('fooGateway (Payum\Core\Gateway):', $output);
+        $this->assertStringContainsString('barGateway (Payum\Core\Gateway):', $output);
     }
 
     /**
      * @test
      */
-    public function shouldOutputInfoWhatActionsSupports()
+    public function shouldOutputInfoWhatActionsSupports(): void
     {
         $output = $this->executeConsole(new DebugGatewayCommand(), array(
             'gateway-name' => 'fooGateway',
             '--show-supports' => true,
         ));
 
-        $this->assertContains('Found 1 gateways', $output);
-        $this->assertContains('fooGateway (Payum\Core\Gateway):', $output);
-        $this->assertContains('Payum\Offline\Action\CaptureAction', $output);
-        $this->assertContains('$request instanceof Capture &&', $output);
-        $this->assertContains('$request->getModel() instanceof PaymentInterface', $output);
+        $this->assertStringContainsString('Found 1 gateways', $output);
+        $this->assertStringContainsString('fooGateway (Payum\Core\Gateway):', $output);
+        $this->assertStringContainsString('Payum\Offline\Action\CaptureAction', $output);
+        $this->assertStringContainsString('$request instanceof Capture &&', $output);
+        $this->assertStringContainsString('$request->getModel() instanceof PaymentInterface', $output);
     }
 
     /**
      * @test
      */
-    public function shouldOutputChoiceListGatewaysForNameGiven()
+    public function shouldOutputChoiceListGatewaysForNameGiven(): void
     {
         $command = new DebugGatewayCommand();
         $command->setApplication(new Application($this->client->getKernel()));
@@ -73,8 +73,8 @@ class DebugGatewayCommandTest extends WebTestCase
             'gateway-name' => 'foo',
         ], ['0']);
 
-        $this->assertContains('Choose a number for more information on the payum gateway', $output);
-        $this->assertContains('[0] fooGateway', $output);
+        $this->assertStringContainsString('Choose a number for more information on the payum gateway', $output);
+        $this->assertStringContainsString('[0] fooGateway', $output);
     }
 
     /**
@@ -84,7 +84,7 @@ class DebugGatewayCommandTest extends WebTestCase
      *
      * @return string
      */
-    protected function executeConsole(Command $command, array $arguments = [], array $inputs = [])
+    protected function executeConsole(Command $command, array $arguments = [], array $inputs = []): string
     {
         if (!$command->getApplication()) {
             $command->setApplication(new Application($this->client->getKernel()));
@@ -110,7 +110,7 @@ class DebugGatewayCommandTest extends WebTestCase
     protected function getInputStream($input)
     {
         $stream = fopen('php://memory', 'r+', false);
-        fputs($stream, $input);
+        fwrite($stream, $input);
         rewind($stream);
 
         return $stream;

--- a/Tests/Functional/Command/StatusCommandTest.php
+++ b/Tests/Functional/Command/StatusCommandTest.php
@@ -14,7 +14,7 @@ class StatusCommandTest extends WebTestCase
     /**
      * @test
      */
-    public function shouldReturnNewStatus()
+    public function shouldReturnNewStatus(): void
     {
         /** @var RegistryInterface $payum */
         $payum = $this->client->getContainer()->get('payum');
@@ -33,7 +33,7 @@ class StatusCommandTest extends WebTestCase
             '--model-id' => $modelId
         ));
 
-        $this->assertContains("Status: new", $output);
+        $this->assertStringContainsString("Status: new", $output);
     }
 
     /**
@@ -42,7 +42,7 @@ class StatusCommandTest extends WebTestCase
      *
      * @return string
      */
-    protected function executeConsole(Command $command, array $arguments = array())
+    protected function executeConsole(Command $command, array $arguments = array()): string
     {
         $command->setApplication(new Application($this->client->getKernel()));
         if ($command instanceof ContainerAwareInterface) {

--- a/Tests/Functional/Controller/AuthorizeControllerTest.php
+++ b/Tests/Functional/Controller/AuthorizeControllerTest.php
@@ -10,7 +10,7 @@ class AuthorizeControllerTest extends WebTestCase
     /**
      * @ticket 507
      */
-    public function testCanBeAccessed()
+    public function testCanBeAccessed(): void
     {
         $this->expectException(NotFoundHttpException::class);
         $this->expectExceptionMessage('A token with hash `payum_token` could not be found.');

--- a/Tests/Functional/Controller/CancelControllerTest.php
+++ b/Tests/Functional/Controller/CancelControllerTest.php
@@ -10,7 +10,7 @@ class CancelControllerTest extends WebTestCase
     /**
      * @ticket 507
      */
-    public function testCanBeAccessed()
+    public function testCanBeAccessed(): void
     {
         $this->expectException(NotFoundHttpException::class);
         $this->expectExceptionMessage('A token with hash `payum_token` could not be found.');

--- a/Tests/Functional/Controller/CaptureControllerTest.php
+++ b/Tests/Functional/Controller/CaptureControllerTest.php
@@ -10,7 +10,7 @@ class CaptureControllerTest extends WebTestCase
     /**
      * @ticket 507
      */
-    public function testCanBeAccessed()
+    public function testCanBeAccessed(): void
     {
         $this->expectException(NotFoundHttpException::class);
         $this->expectExceptionMessage('A token with hash `payum_token` could not be found.');

--- a/Tests/Functional/Controller/NotifyControllerTest.php
+++ b/Tests/Functional/Controller/NotifyControllerTest.php
@@ -10,7 +10,7 @@ class NotifyControllerTest extends WebTestCase
     /**
      * @ticket 507
      */
-    public function testCanBeAccessed()
+    public function testCanBeAccessed(): void
     {
         $this->expectException(NotFoundHttpException::class);
         $this->expectExceptionMessage('A token with hash `payum_token` could not be found.');

--- a/Tests/Functional/Controller/PayoutControllerTest.php
+++ b/Tests/Functional/Controller/PayoutControllerTest.php
@@ -10,7 +10,7 @@ class PayoutControllerTest extends WebTestCase
     /**
      * @ticket 507
      */
-    public function testCanBeAccessed()
+    public function testCanBeAccessed(): void
     {
         $this->expectException(NotFoundHttpException::class);
         $this->expectExceptionMessage('A token with hash `payum_token` could not be found.');

--- a/Tests/Functional/Controller/RefundControllerTest.php
+++ b/Tests/Functional/Controller/RefundControllerTest.php
@@ -10,7 +10,7 @@ class RefundControllerTest extends WebTestCase
     /**
      * @ticket 507
      */
-    public function testCanBeAccessed()
+    public function testCanBeAccessed(): void
     {
         $this->expectException(NotFoundHttpException::class);
         $this->expectExceptionMessage('A token with hash `payum_token` could not be found.');

--- a/Tests/Functional/Controller/SyncControllerTest.php
+++ b/Tests/Functional/Controller/SyncControllerTest.php
@@ -10,7 +10,7 @@ class SyncControllerTest extends WebTestCase
     /**
      * @ticket 507
      */
-    public function testCanBeAccessed()
+    public function testCanBeAccessed(): void
     {
         $this->expectException(NotFoundHttpException::class);
         $this->expectExceptionMessage('A token with hash `payum_token` could not be found.');

--- a/Tests/Functional/DependencyInjection/MainConfigurationTest.php
+++ b/Tests/Functional/DependencyInjection/MainConfigurationTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 class MainConfigurationTest extends TestCase
 {
-    protected $storageFactories = array();
+    protected array $storageFactories = array();
 
     protected function setUp(): void
     {
@@ -22,8 +22,10 @@ class MainConfigurationTest extends TestCase
     /**
      * @test
      */
-    public function shouldPassConfigurationProcessingWithMinimumConfig()
+    public function shouldPassConfigurationProcessingWithMinimumConfig(): void
     {
+        $this->expectNotToPerformAssertions();
+
         $configuration = new MainConfiguration($this->storageFactories);
 
         $processor = new Processor();
@@ -48,8 +50,9 @@ class MainConfigurationTest extends TestCase
     /**
      * @test
      */
-    public function shouldPassConfigurationProcessingWithMinimumConfigPlusGateway()
+    public function shouldPassConfigurationProcessingWithMinimumConfigPlusGateway(): void
     {
+        $this->expectNotToPerformAssertions();
         $configuration = new MainConfiguration($this->storageFactories);
 
         $processor = new Processor();
@@ -82,8 +85,10 @@ class MainConfigurationTest extends TestCase
     /**
      * @test
      */
-    public function shouldPassConfigurationProcessingWithDynamicGateways()
+    public function shouldPassConfigurationProcessingWithDynamicGateways(): void
     {
+        $this->expectNotToPerformAssertions();
+
         $configuration = new MainConfiguration($this->storageFactories);
 
         $processor = new Processor();
@@ -116,8 +121,10 @@ class MainConfigurationTest extends TestCase
     /**
      * @test
      */
-    public function shouldPassConfigurationProcessingWithDynamicGatewaysAndEncryption()
+    public function shouldPassConfigurationProcessingWithDynamicGatewaysAndEncryption(): void
     {
+        $this->expectNotToPerformAssertions();
+
         $configuration = new MainConfiguration($this->storageFactories);
 
         $processor = new Processor();
@@ -153,8 +160,10 @@ class MainConfigurationTest extends TestCase
     /**
      * @test
      */
-    public function shouldPassConfigurationProcessingWithDynamicGatewaysPlusSonataAdmin()
+    public function shouldPassConfigurationProcessingWithDynamicGatewaysPlusSonataAdmin(): void
     {
+        $this->expectNotToPerformAssertions();
+
         $configuration = new MainConfiguration($this->storageFactories);
 
         $processor = new Processor();
@@ -188,8 +197,10 @@ class MainConfigurationTest extends TestCase
     /**
      * @test
      */
-    public function shouldPassConfigurationProcessingWithKlarnaCheckoutGatewayFactory()
+    public function shouldPassConfigurationProcessingWithKlarnaCheckoutGatewayFactory(): void
     {
+        $this->expectNotToPerformAssertions();
+
         $configuration = new MainConfiguration($this->storageFactories);
 
         $processor = new Processor();
@@ -222,8 +233,10 @@ class MainConfigurationTest extends TestCase
     /**
      * @test
      */
-    public function shouldPassConfigurationProcessingWithDoctrineStorageFactory()
+    public function shouldPassConfigurationProcessingWithDoctrineStorageFactory(): void
     {
+        $this->expectNotToPerformAssertions();
+
         $configuration = new MainConfiguration($this->storageFactories);
 
         $processor = new Processor();
@@ -262,8 +275,10 @@ class MainConfigurationTest extends TestCase
     /**
      * @test
      */
-    public function shouldPassConfigurationProcessingWithFilesystemStorageFactory()
+    public function shouldPassConfigurationProcessingWithFilesystemStorageFactory(): void
     {
+        $this->expectNotToPerformAssertions();
+
         $configuration = new MainConfiguration($this->storageFactories);
 
         $processor = new Processor();

--- a/Tests/Functional/DependencyInjection/PayumExtensionTest.php
+++ b/Tests/Functional/DependencyInjection/PayumExtensionTest.php
@@ -15,7 +15,7 @@ class PayumExtensionTest extends TestCase
     /**
      * @test
      */
-    public function shouldAddGatewayTagWithCorrectGatewayAndFactoryNamesSet()
+    public function shouldAddGatewayTagWithCorrectGatewayAndFactoryNamesSet(): void
     {
         $this->markTestSkipped();
 
@@ -68,7 +68,7 @@ class PayumExtensionTest extends TestCase
     /**
      * @test
      */
-    public function shouldUsePayumBuilderServiceToBuildPayumService()
+    public function shouldUsePayumBuilderServiceToBuildPayumService(): void
     {
         $config = array(
             // 'dynamic_gateways' => array()
@@ -96,7 +96,7 @@ class PayumExtensionTest extends TestCase
 
         $payum = $containerBuilder->getDefinition('payum');
         $this->assertEquals('Payum\Core\Payum', $payum->getClass());
-        $this->assertInternalType('array', $payum->getFactory());
+        $this->assertIsArray($payum->getFactory());
 
         $this->assertInstanceOf(Reference::class, $payum->getFactory()[0]);
         $this->assertEquals('payum.builder', (string) $payum->getFactory()[0]);
@@ -107,7 +107,7 @@ class PayumExtensionTest extends TestCase
     /**
      * @test
      */
-    public function shouldSetGatewayConfigStorageToPayumBuilderIfConfigured()
+    public function shouldSetGatewayConfigStorageToPayumBuilderIfConfigured(): void
     {
         $config = array(
             'dynamic_gateways' => array(
@@ -155,7 +155,7 @@ class PayumExtensionTest extends TestCase
     /**
      * @test
      */
-    public function shouldWrapGatewayConfigStorageByEncryptionDecoratorWhenDefuseEncryptionIsEnabled()
+    public function shouldWrapGatewayConfigStorageByEncryptionDecoratorWhenDefuseEncryptionIsEnabled(): void
     {
         $config = array(
             'dynamic_gateways' => array(
@@ -210,7 +210,7 @@ class PayumExtensionTest extends TestCase
     /**
      * @test
      */
-    public function shouldConfigureSonataAdminClassForGatewayConfigModelSetInStorageSection()
+    public function shouldConfigureSonataAdminClassForGatewayConfigModelSetInStorageSection(): void
     {
         $this->markTestSkipped('Has to wait for Sonata Admin Sf4 compatible release');
 
@@ -265,7 +265,7 @@ class PayumExtensionTest extends TestCase
     /**
      * @test
      */
-    public function shouldInjectCypherToForGatewayConfigAdmin()
+    public function shouldInjectCypherToForGatewayConfigAdmin(): void
     {
         $this->markTestSkipped('Has to wait for Sonata Admin Sf4 compatible release');
 
@@ -320,7 +320,7 @@ class PayumExtensionTest extends TestCase
     /**
      * @test
      */
-    public function shouldNotConfigureSonataAdminClassForGatewayConfigIfDisabled()
+    public function shouldNotConfigureSonataAdminClassForGatewayConfigIfDisabled(): void
     {
         $config = array(
             'dynamic_gateways' => array(
@@ -366,7 +366,7 @@ class TestGatewayConfig implements GatewayConfigInterface
     {
     }
 
-    public function setGatewayName($gatewayName)
+    public function setGatewayName($gatewayName): void
     {
     }
 
@@ -374,11 +374,11 @@ class TestGatewayConfig implements GatewayConfigInterface
     {
     }
 
-    public function setFactoryName($name)
+    public function setFactoryName($name): void
     {
     }
 
-    public function setConfig(array $config)
+    public function setConfig(array $config): void
     {
     }
 

--- a/Tests/Functional/EventListener/ReplyToHttpResponseListenerTest.php
+++ b/Tests/Functional/EventListener/ReplyToHttpResponseListenerTest.php
@@ -8,7 +8,7 @@ class ReplyToHttpResponseListenerTest extends WebTestCase
     /**
      * @test
      */
-    public function couldBeGetFromContainerAsService()
+    public function couldBeGetFromContainerAsService(): void
     {
         $listener = static::$container->get('payum.listener.reply_to_http_response');
 

--- a/Tests/Functional/Form/Type/CreditCardExpirationDateTypeTest.php
+++ b/Tests/Functional/Form/Type/CreditCardExpirationDateTypeTest.php
@@ -24,7 +24,7 @@ class CreditCardExpirationDateTypeTest extends WebTestCase
     /**
      * @test
      */
-    public function couldBeCreatedByFormFactory()
+    public function couldBeCreatedByFormFactory(): void
     {
         $form = $this->formFactory->create(CreditCardExpirationDateType::class);
         $view = $form->createView();
@@ -36,7 +36,7 @@ class CreditCardExpirationDateTypeTest extends WebTestCase
     /**
      * @test
      */
-    public function shouldAllowSubmitExpireDateAsChoice()
+    public function shouldAllowSubmitExpireDateAsChoice(): void
     {
         $form = $this->formFactory->create(CreditCardExpirationDateType::class, null, array(
             'widget' => 'choice',
@@ -62,7 +62,7 @@ class CreditCardExpirationDateTypeTest extends WebTestCase
     /**
      * @test
      */
-    public function shouldHideDaySelectAndSetFirstDayFromChoiceAsValue()
+    public function shouldHideDaySelectAndSetFirstDayFromChoiceAsValue(): void
     {
         $form = $this->formFactory->create(CreditCardExpirationDateType::class, null, array(
             'widget' => 'choice',
@@ -79,7 +79,7 @@ class CreditCardExpirationDateTypeTest extends WebTestCase
     /**
      * @test
      */
-    public function shouldHideDaySelectAndSetDayFromGivenDateTimeAsValue()
+    public function shouldHideDaySelectAndSetDayFromGivenDateTimeAsValue(): void
     {
         $date = new \DateTime('2020-01-10');
 

--- a/Tests/Functional/Form/Type/CreditCardTypeTest.php
+++ b/Tests/Functional/Form/Type/CreditCardTypeTest.php
@@ -25,7 +25,7 @@ class CreditCardTypeTest extends WebTestCase
     /**
      * @test
      */
-    public function couldBeCreatedByFormFactory()
+    public function couldBeCreatedByFormFactory(): void
     {
         $form = $this->formFactory->create(CreditCardType::class);
         $view = $form->createView();
@@ -37,7 +37,7 @@ class CreditCardTypeTest extends WebTestCase
     /**
      * @test
      */
-    public function shouldSubmitDataCorrectly()
+    public function shouldSubmitDataCorrectly(): void
     {
         $form = $this->formFactory->create(CreditCardType::class, null, array(
             'csrf_protection' => false,
@@ -72,7 +72,7 @@ class CreditCardTypeTest extends WebTestCase
     /**
      * @test
      */
-    public function shouldRequireHolderNotBlank()
+    public function shouldRequireHolderNotBlank(): void
     {
         $form = $this->formFactory->create(CreditCardType::class, null, array(
             'csrf_protection' => false,
@@ -96,7 +96,7 @@ class CreditCardTypeTest extends WebTestCase
     /**
      * @test
      */
-    public function shouldRequireNumberNotBlank()
+    public function shouldRequireNumberNotBlank(): void
     {
         $form = $this->formFactory->create(CreditCardType::class, null, array(
             'csrf_protection' => false,
@@ -120,7 +120,7 @@ class CreditCardTypeTest extends WebTestCase
     /**
      * @test
      */
-    public function shouldNumberPassLuchValidation()
+    public function shouldNumberPassLuchValidation(): void
     {
         $form = $this->formFactory->create(CreditCardType::class, null, array(
             'csrf_protection' => false,
@@ -144,7 +144,7 @@ class CreditCardTypeTest extends WebTestCase
     /**
      * @test
      */
-    public function shouldRequireSecurityCodeNotBlank()
+    public function shouldRequireSecurityCodeNotBlank(): void
     {
         $form = $this->formFactory->create(CreditCardType::class, null, array(
             'csrf_protection' => false,
@@ -168,7 +168,7 @@ class CreditCardTypeTest extends WebTestCase
     /**
      * @test
      */
-    public function shouldRequireExpireAtNotBlank()
+    public function shouldRequireExpireAtNotBlank(): void
     {
         $form = $this->formFactory->create(CreditCardType::class, null, array(
             'csrf_protection' => false,
@@ -192,7 +192,7 @@ class CreditCardTypeTest extends WebTestCase
     /**
      * @test
      */
-    public function shouldRequireExpireAtInFuture()
+    public function shouldRequireExpireAtInFuture(): void
     {
         $form = $this->formFactory->create(CreditCardType::class, null, array(
             'csrf_protection' => false,

--- a/Tests/Functional/Form/Type/GatewayConfigTypeTest.php
+++ b/Tests/Functional/Form/Type/GatewayConfigTypeTest.php
@@ -25,7 +25,7 @@ class GatewayConfigTypeTest extends WebTestCase
     /**
      * @test
      */
-    public function couldBeCreatedByFormFactory()
+    public function couldBeCreatedByFormFactory(): void
     {
         $form = $this->formFactory->create(GatewayConfigType::class, null, array(
             'data_class' => GatewayConfig::class,

--- a/Tests/Functional/Form/Type/GatewayFactoriesChoiceTypeTest.php
+++ b/Tests/Functional/Form/Type/GatewayFactoriesChoiceTypeTest.php
@@ -24,7 +24,7 @@ class GatewayFactoriesChoiceTypeTest extends WebTestCase
     /**
      * @test
      */
-    public function couldBeCreatedByFormFactory()
+    public function couldBeCreatedByFormFactory(): void
     {
         $form = $this->formFactory->create(GatewayFactoriesChoiceType::class);
         $view = $form->createView();

--- a/Tests/Functional/PayumBuilderTest.php
+++ b/Tests/Functional/PayumBuilderTest.php
@@ -23,11 +23,10 @@ class PayumBuilderTest extends WebTestCase
         /** @var PayumBuilder $builder */
         $builder = static::$container->get('payum.builder');
 
-        $this->markTestIncomplete(
-            'Replacement for PhpUnit9 needed. Attribut is not public in Payum\Core\PayumBuilder'
-        );
-        #$this->assertAttributeInstanceOf(CoreGatewayFactoryBuilder::class, 'coreGatewayFactory', $builder);
-        #$this->assertInstanceOf(CoreGatewayFactoryBuilder::class, $builder->coreGatewayFactory);
+        $reflected_constraint = (new \ReflectionObject($builder))->getProperty('coreGatewayFactory');
+        $reflected_constraint->setAccessible(TRUE);
+        $constraint = $reflected_constraint->getValue($builder);
+        $this->assertInstanceOf(CoreGatewayFactoryBuilder::class, $constraint);
     }
 
     public function testShouldContainHttpRequestVerifierBuilder(): void
@@ -35,11 +34,10 @@ class PayumBuilderTest extends WebTestCase
         /** @var PayumBuilder $builder */
         $builder = static::$container->get('payum.builder');
 
-        $this->markTestIncomplete(
-            'Replacement for PhpUnit9 needed. Attribut is not public in Payum\Core\PayumBuilder'
-        );
-        #$this->assertAttributeInstanceOf(HttpRequestVerifierBuilder::class, 'httpRequestVerifier', $builder);
-        #$this->assertInstanceOf(HttpRequestVerifierBuilder::class, $builder->httpRequestVerifier);
+        $reflected_constraint = (new \ReflectionObject($builder))->getProperty('httpRequestVerifier');
+        $reflected_constraint->setAccessible(TRUE);
+        $constraint = $reflected_constraint->getValue($builder);
+        $this->assertInstanceOf(HttpRequestVerifierBuilder::class, $constraint);
     }
 
     public function testShouldContainTokenFactoryBuilder(): void
@@ -47,11 +45,10 @@ class PayumBuilderTest extends WebTestCase
         /** @var PayumBuilder $builder */
         $builder = static::$container->get('payum.builder');
 
-        $this->markTestIncomplete(
-            'Replacement for PhpUnit9 needed. Attribut is not public in Payum\Core\PayumBuilder'
-        );
-        #$this->assertAttributeInstanceOf(TokenFactoryBuilder::class, 'tokenFactory', $builder);
-        #$this->assertInstanceOf(TokenFactoryBuilder::class, $builder->tokenFactory);
+        $reflected_constraint = (new \ReflectionObject($builder))->getProperty('tokenFactory');
+        $reflected_constraint->setAccessible(TRUE);
+        $constraint = $reflected_constraint->getValue($builder);
+        $this->assertInstanceOf(TokenFactoryBuilder::class, $constraint);
     }
 
     public function testShouldContainMainRegistry(): void
@@ -59,11 +56,10 @@ class PayumBuilderTest extends WebTestCase
         /** @var PayumBuilder $builder */
         $builder = static::$container->get('payum.builder');
 
-        $this->markTestIncomplete(
-            'Replacement for PhpUnit9 needed. Attribut is not public in Payum\Core\Bridge\Symfony\ContainerAwareRegistry'
-        );
-        #$this->assertAttributeInstanceOf(ContainerAwareRegistry::class, 'mainRegistry', $builder);
-        #$this->assertInstanceOf(ContainerAwareRegistry::class, $builder->mainRegistry);
+        $reflected_constraint = (new \ReflectionObject($builder))->getProperty('mainRegistry');
+        $reflected_constraint->setAccessible(TRUE);
+        $constraint = $reflected_constraint->getValue($builder);
+        $this->assertInstanceOf(ContainerAwareRegistry::class, $constraint);
     }
 
     public function testShouldContainGenericTokenFactoryPaths(): void
@@ -71,17 +67,15 @@ class PayumBuilderTest extends WebTestCase
         /** @var PayumBuilder $builder */
         $builder = static::$container->get('payum.builder');
 
-        $this->markTestIncomplete(
-            'Replacement for PhpUnit9 needed.'
-        );
+        $reflected_constraint = (new \ReflectionObject($builder))->getProperty('genericTokenFactoryPaths');
+        $reflected_constraint->setAccessible(TRUE);
+        $constraint = $reflected_constraint->getValue($builder);
 
-        $this->assertAttributeEquals([
-            'capture' => 'payum_capture_do',
-            'notify' => 'payum_notify_do',
-            'authorize' => 'payum_authorize_do',
-            'refund' => 'payum_refund_do',
-            'cancel' => 'payum_cancel_do',
-            'payout' => 'payum_payout_do',
-        ], 'genericTokenFactoryPaths', $builder);
+        $this->assertEquals('payum_capture_do', $constraint['capture']);
+        $this->assertEquals('payum_notify_do', $constraint['notify']);
+        $this->assertEquals('payum_authorize_do', $constraint['authorize']);
+        $this->assertEquals('payum_refund_do', $constraint['refund']);
+        $this->assertEquals('payum_cancel_do', $constraint['cancel']);
+        $this->assertEquals('payum_payout_do', $constraint['payout']);
     }
 }

--- a/Tests/Functional/PayumBuilderTest.php
+++ b/Tests/Functional/PayumBuilderTest.php
@@ -23,9 +23,9 @@ class PayumBuilderTest extends WebTestCase
         /** @var PayumBuilder $builder */
         $builder = static::$container->get('payum.builder');
 
-        $reflected_constraint = (new \ReflectionObject($builder))->getProperty('coreGatewayFactory');
-        $reflected_constraint->setAccessible(TRUE);
-        $constraint = $reflected_constraint->getValue($builder);
+        $reflectedConstraint = (new \ReflectionObject($builder))->getProperty('coreGatewayFactory');
+        $reflectedConstraint->setAccessible(true);
+        $constraint = $reflectedConstraint->getValue($builder);
         $this->assertInstanceOf(CoreGatewayFactoryBuilder::class, $constraint);
     }
 
@@ -34,9 +34,9 @@ class PayumBuilderTest extends WebTestCase
         /** @var PayumBuilder $builder */
         $builder = static::$container->get('payum.builder');
 
-        $reflected_constraint = (new \ReflectionObject($builder))->getProperty('httpRequestVerifier');
-        $reflected_constraint->setAccessible(TRUE);
-        $constraint = $reflected_constraint->getValue($builder);
+        $reflectedConstraint = (new \ReflectionObject($builder))->getProperty('httpRequestVerifier');
+        $reflectedConstraint->setAccessible(true);
+        $constraint = $reflectedConstraint->getValue($builder);
         $this->assertInstanceOf(HttpRequestVerifierBuilder::class, $constraint);
     }
 
@@ -45,9 +45,9 @@ class PayumBuilderTest extends WebTestCase
         /** @var PayumBuilder $builder */
         $builder = static::$container->get('payum.builder');
 
-        $reflected_constraint = (new \ReflectionObject($builder))->getProperty('tokenFactory');
-        $reflected_constraint->setAccessible(TRUE);
-        $constraint = $reflected_constraint->getValue($builder);
+        $reflectedConstraint = (new \ReflectionObject($builder))->getProperty('tokenFactory');
+        $reflectedConstraint->setAccessible(true);
+        $constraint = $reflectedConstraint->getValue($builder);
         $this->assertInstanceOf(TokenFactoryBuilder::class, $constraint);
     }
 
@@ -56,9 +56,9 @@ class PayumBuilderTest extends WebTestCase
         /** @var PayumBuilder $builder */
         $builder = static::$container->get('payum.builder');
 
-        $reflected_constraint = (new \ReflectionObject($builder))->getProperty('mainRegistry');
-        $reflected_constraint->setAccessible(TRUE);
-        $constraint = $reflected_constraint->getValue($builder);
+        $reflectedConstraint = (new \ReflectionObject($builder))->getProperty('mainRegistry');
+        $reflectedConstraint->setAccessible(true);
+        $constraint = $reflectedConstraint->getValue($builder);
         $this->assertInstanceOf(ContainerAwareRegistry::class, $constraint);
     }
 
@@ -67,9 +67,9 @@ class PayumBuilderTest extends WebTestCase
         /** @var PayumBuilder $builder */
         $builder = static::$container->get('payum.builder');
 
-        $reflected_constraint = (new \ReflectionObject($builder))->getProperty('genericTokenFactoryPaths');
-        $reflected_constraint->setAccessible(TRUE);
-        $constraint = $reflected_constraint->getValue($builder);
+        $reflectedConstraint = (new \ReflectionObject($builder))->getProperty('genericTokenFactoryPaths');
+        $reflectedConstraint->setAccessible(true);
+        $constraint = $reflectedConstraint->getValue($builder);
 
         $this->assertEquals('payum_capture_do', $constraint['capture']);
         $this->assertEquals('payum_notify_do', $constraint['notify']);

--- a/Tests/Functional/PayumBuilderTest.php
+++ b/Tests/Functional/PayumBuilderTest.php
@@ -9,7 +9,7 @@ use Payum\Core\PayumBuilder;
 
 class PayumBuilderTest extends WebTestCase
 {
-    public function testCouldBeGetFromContainerAsService()
+    public function testCouldBeGetFromContainerAsService(): void
     {
         /** @var PayumBuilder $builder */
         $builder = static::$container->get('payum.builder');
@@ -17,42 +17,63 @@ class PayumBuilderTest extends WebTestCase
         $this->assertInstanceOf(PayumBuilder::class, $builder);
     }
 
-    public function testShouldContainCoreGatewayFactoryBuilder()
+
+    public function testShouldContainCoreGatewayFactoryBuilder(): void
     {
         /** @var PayumBuilder $builder */
         $builder = static::$container->get('payum.builder');
 
-        $this->assertAttributeInstanceOf(CoreGatewayFactoryBuilder::class, 'coreGatewayFactory', $builder);
+        $this->markTestIncomplete(
+            'Replacement for PhpUnit9 needed. Attribut is not public in Payum\Core\PayumBuilder'
+        );
+        #$this->assertAttributeInstanceOf(CoreGatewayFactoryBuilder::class, 'coreGatewayFactory', $builder);
+        #$this->assertInstanceOf(CoreGatewayFactoryBuilder::class, $builder->coreGatewayFactory);
     }
 
-    public function testShouldContainHttpRequestVerifierBuilder()
+    public function testShouldContainHttpRequestVerifierBuilder(): void
     {
         /** @var PayumBuilder $builder */
         $builder = static::$container->get('payum.builder');
 
-        $this->assertAttributeInstanceOf(HttpRequestVerifierBuilder::class, 'httpRequestVerifier', $builder);
+        $this->markTestIncomplete(
+            'Replacement for PhpUnit9 needed. Attribut is not public in Payum\Core\PayumBuilder'
+        );
+        #$this->assertAttributeInstanceOf(HttpRequestVerifierBuilder::class, 'httpRequestVerifier', $builder);
+        #$this->assertInstanceOf(HttpRequestVerifierBuilder::class, $builder->httpRequestVerifier);
     }
 
-    public function testShouldContainTokenFactoryBuilder()
+    public function testShouldContainTokenFactoryBuilder(): void
     {
         /** @var PayumBuilder $builder */
         $builder = static::$container->get('payum.builder');
 
-        $this->assertAttributeInstanceOf(TokenFactoryBuilder::class, 'tokenFactory', $builder);
+        $this->markTestIncomplete(
+            'Replacement for PhpUnit9 needed. Attribut is not public in Payum\Core\PayumBuilder'
+        );
+        #$this->assertAttributeInstanceOf(TokenFactoryBuilder::class, 'tokenFactory', $builder);
+        #$this->assertInstanceOf(TokenFactoryBuilder::class, $builder->tokenFactory);
     }
 
-    public function testShouldContainMainRegistry()
+    public function testShouldContainMainRegistry(): void
     {
         /** @var PayumBuilder $builder */
         $builder = static::$container->get('payum.builder');
 
-        $this->assertAttributeInstanceOf(ContainerAwareRegistry::class, 'mainRegistry', $builder);
+        $this->markTestIncomplete(
+            'Replacement for PhpUnit9 needed. Attribut is not public in Payum\Core\Bridge\Symfony\ContainerAwareRegistry'
+        );
+        #$this->assertAttributeInstanceOf(ContainerAwareRegistry::class, 'mainRegistry', $builder);
+        #$this->assertInstanceOf(ContainerAwareRegistry::class, $builder->mainRegistry);
     }
 
-    public function testShouldContainGenericTokenFactoryPaths()
+    public function testShouldContainGenericTokenFactoryPaths(): void
     {
         /** @var PayumBuilder $builder */
         $builder = static::$container->get('payum.builder');
+
+        $this->markTestIncomplete(
+            'Replacement for PhpUnit9 needed.'
+        );
 
         $this->assertAttributeEquals([
             'capture' => 'payum_capture_do',

--- a/Tests/Functional/PayumTest.php
+++ b/Tests/Functional/PayumTest.php
@@ -37,11 +37,10 @@ class PayumTest extends WebTestCase
         $tokenFactory = $payum->getTokenFactory();
         $this->assertInstanceOf(GenericTokenFactory::class, $tokenFactory);
 
-        $this->markTestIncomplete(
-            'Replacement for PhpUnit9 needed. Attribut is not public in Payum\Core\Bridge\Symfony\Security\TokenFactory'
-        );
-        #$this->assertAttributeInstanceOf(TokenFactory::class, 'tokenFactory', $tokenFactory);
-        #$this->assertInstanceOf(TokenFactory::class, $tokenFactory->tokenFactory);
+        $reflected_constraint = (new \ReflectionObject($tokenFactory))->getProperty('tokenFactory');
+        $reflected_constraint->setAccessible(TRUE);
+        $constraint = $reflected_constraint->getValue($tokenFactory);
+        $this->assertInstanceOf(TokenFactory::class, $constraint);
     }
 
     public function testShouldReturnTokenStorage(): void

--- a/Tests/Functional/PayumTest.php
+++ b/Tests/Functional/PayumTest.php
@@ -13,7 +13,7 @@ use Payum\Stripe\StripeJsGatewayFactory;
 
 class PayumTest extends WebTestCase
 {
-    public function testCouldBeGetFromContainerAsService()
+    public function testCouldBeGetFromContainerAsService(): void
     {
         /** @var Payum $payum */
         $payum = static::$container->get('payum');
@@ -21,7 +21,7 @@ class PayumTest extends WebTestCase
         $this->assertInstanceOf(Payum::class, $payum);
     }
 
-    public function testShouldReturnHttpRequestVerifyRequest()
+    public function testShouldReturnHttpRequestVerifyRequest(): void
     {
         /** @var Payum $payum */
         $payum = static::$container->get('payum');
@@ -29,17 +29,22 @@ class PayumTest extends WebTestCase
         $this->assertInstanceOf(HttpRequestVerifier::class, $payum->getHttpRequestVerifier());
     }
 
-    public function testShouldReturnTokenFactory()
+    public function testShouldReturnTokenFactory(): void
     {
         /** @var Payum $payum */
         $payum = static::$container->get('payum');
 
         $tokenFactory = $payum->getTokenFactory();
         $this->assertInstanceOf(GenericTokenFactory::class, $tokenFactory);
-        $this->assertAttributeInstanceOf(TokenFactory::class, 'tokenFactory', $tokenFactory);
+
+        $this->markTestIncomplete(
+            'Replacement for PhpUnit9 needed. Attribut is not public in Payum\Core\Bridge\Symfony\Security\TokenFactory'
+        );
+        #$this->assertAttributeInstanceOf(TokenFactory::class, 'tokenFactory', $tokenFactory);
+        #$this->assertInstanceOf(TokenFactory::class, $tokenFactory->tokenFactory);
     }
 
-    public function testShouldReturnTokenStorage()
+    public function testShouldReturnTokenStorage(): void
     {
         /** @var Payum $payum */
         $payum = static::$container->get('payum');
@@ -48,37 +53,37 @@ class PayumTest extends WebTestCase
         $this->assertInstanceOf(StorageInterface::class, $storage);
     }
 
-    public function testShouldReturnStorages()
+    public function testShouldReturnStorages(): void
     {
         /** @var Payum $payum */
         $payum = static::$container->get('payum');
 
         $storages = $payum->getStorages();
-        $this->assertInternalType('array', $storages);
+        $this->assertIsArray($storages);
         $this->assertCount(1, $storages);
     }
 
-    public function testShouldReturnGateways()
+    public function testShouldReturnGateways(): void
     {
         /** @var Payum $payum */
         $payum = static::$container->get('payum');
 
         $gateways = $payum->getGateways();
-        $this->assertInternalType('array', $gateways);
+        $this->assertIsArray($gateways);
         $this->assertCount(2, $gateways);
     }
 
-    public function testShouldReturnGatewaysFactories()
+    public function testShouldReturnGatewaysFactories(): void
     {
         /** @var Payum $payum */
         $payum = static::$container->get('payum');
 
         $factories = $payum->getGatewayFactories();
-        $this->assertInternalType('array', $factories);
+        $this->assertIsArray($factories);
         $this->assertGreaterThan(10, count($factories));
     }
 
-    public function testShouldReturnGatewayFactory()
+    public function testShouldReturnGatewayFactory(): void
     {
         /** @var Payum $payum */
         $payum = static::$container->get('payum');
@@ -87,7 +92,7 @@ class PayumTest extends WebTestCase
         $this->assertInstanceOf(StripeJsGatewayFactory::class, $payum->getGatewayFactory('stripe_js'));
     }
 
-    public function testShouldReturnGateway()
+    public function testShouldReturnGateway(): void
     {
         /** @var Payum $payum */
         $payum = static::$container->get('payum');
@@ -96,7 +101,7 @@ class PayumTest extends WebTestCase
         $this->assertInstanceOf(GatewayInterface::class, $payum->getGateway('barGateway'));
     }
 
-    public function testShouldReturnStorage()
+    public function testShouldReturnStorage(): void
     {
         /** @var Payum $payum */
         $payum = static::$container->get('payum');

--- a/Tests/Functional/PayumTest.php
+++ b/Tests/Functional/PayumTest.php
@@ -37,9 +37,9 @@ class PayumTest extends WebTestCase
         $tokenFactory = $payum->getTokenFactory();
         $this->assertInstanceOf(GenericTokenFactory::class, $tokenFactory);
 
-        $reflected_constraint = (new \ReflectionObject($tokenFactory))->getProperty('tokenFactory');
-        $reflected_constraint->setAccessible(TRUE);
-        $constraint = $reflected_constraint->getValue($tokenFactory);
+        $reflectedConstraint = (new \ReflectionObject($tokenFactory))->getProperty('tokenFactory');
+        $reflectedConstraint->setAccessible(true);
+        $constraint = $reflectedConstraint->getValue($tokenFactory);
         $this->assertInstanceOf(TokenFactory::class, $constraint);
     }
 

--- a/Tests/Functional/WebTestCase.php
+++ b/Tests/Functional/WebTestCase.php
@@ -7,10 +7,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 abstract class WebTestCase extends BaseWebTestCase
 {
-    /**
-     * @var KernelBrowser
-     */
-    protected $client;
+    protected KernelBrowser $client;
 
     /**
      * @var ContainerInterface
@@ -25,10 +22,7 @@ abstract class WebTestCase extends BaseWebTestCase
         static::$container = static::$kernel->getContainer();
     }
 
-    /**
-     * @return string
-     */
-    public static function getKernelClass()
+    public static function getKernelClass(): string
     {
         require_once __DIR__ . '/app/AppKernel.php';
 

--- a/Tests/Functional/app/AppKernel.php
+++ b/Tests/Functional/app/AppKernel.php
@@ -11,7 +11,7 @@ if(Kernel::MAJOR_VERSION===4)
 {
     class AppKernel extends AppKernelShared
     {
-        public function handle(Request $request, $type = HttpKernelInterface::MAIN_REQUEST, $catch = true): Response
+        public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true): Response
         {
             return parent::handle($request, $type, false);
         }

--- a/Tests/Functional/app/AppKernel.php
+++ b/Tests/Functional/app/AppKernel.php
@@ -1,44 +1,29 @@
 <?php
 
+use Payum\Bundle\PayumBundle\Tests\Functional\app\AppKernelShared;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Kernel;
-use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
-class AppKernel extends Kernel
+# Could be simplified after support of symfony 4 support is dropped
+if(Kernel::MAJOR_VERSION===4)
 {
-    public function registerBundles(): array
+    class AppKernel extends AppKernelShared
     {
-        $bundles = array(
-            new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
-            new Symfony\Bundle\TwigBundle\TwigBundle(),
-            new Payum\Bundle\PayumBundle\PayumBundle(),
-        );
-
-        return $bundles;
+        public function handle(Request $request, $type = HttpKernelInterface::MAIN_REQUEST, $catch = true): Response
+        {
+            return parent::handle($request, $type, false);
+        }
     }
-
-    public function handle(Request $request, int $type = HttpKernelInterface::MASTER_REQUEST, bool $catch = true): Response
+}
+else
+{
+    class AppKernel extends AppKernelShared
     {
-        /** @noinspection SuspiciousAssignmentsInspection */
-        $catch = false;
-
-        return parent::handle($request, $type, $catch);
-    }
-
-    public function getCacheDir(): string
-    {
-        return sys_get_temp_dir() . '/PayumBundle/cache';
-    }
-
-    public function getLogDir(): string
-    {
-        return sys_get_temp_dir() . '/PayumBundle/logs';
-    }
-
-    public function registerContainerConfiguration(LoaderInterface $loader): void
-    {
-        $loader->load(__DIR__ . '/config/config.yml');
+        public function handle(Request $request, int $type = HttpKernelInterface::MAIN_REQUEST, bool $catch = true): Response
+        {
+            return parent::handle($request, $type, false);
+        }
     }
 }

--- a/Tests/Functional/app/AppKernel.php
+++ b/Tests/Functional/app/AppKernel.php
@@ -1,4 +1,6 @@
 <?php
+
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -6,55 +8,36 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class AppKernel extends Kernel
 {
-    /**
-     * @return array
-     */
-    public function registerBundles()
+    public function registerBundles(): array
     {
         $bundles = array(
             new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
             new Symfony\Bundle\TwigBundle\TwigBundle(),
-
             new Payum\Bundle\PayumBundle\PayumBundle(),
         );
 
         return $bundles;
     }
 
-    /**
-     * @param \Symfony\Component\HttpFoundation\Request $request
-     * @param int $type
-     * @param bool $catch
-     *
-     * @return Symfony\Component\HttpFoundation\Response
-     */
-    public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)
+    public function handle(Request $request, int $type = HttpKernelInterface::MASTER_REQUEST, bool $catch = true): Response
     {
+        /** @noinspection SuspiciousAssignmentsInspection */
         $catch = false;
 
         return parent::handle($request, $type, $catch);
     }
 
-    /**
-     * @return string
-     */
-    public function getCacheDir()
+    public function getCacheDir(): string
     {
         return sys_get_temp_dir() . '/PayumBundle/cache';
     }
 
-    /**
-     * @return string
-     */
-    public function getLogDir()
+    public function getLogDir(): string
     {
         return sys_get_temp_dir() . '/PayumBundle/logs';
     }
 
-    /**
-     * @param \Symfony\Component\Config\Loader\LoaderInterface $loader
-     */
-    public function registerContainerConfiguration(LoaderInterface $loader)
+    public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(__DIR__ . '/config/config.yml');
     }

--- a/Tests/Functional/app/AppKernelShared.php
+++ b/Tests/Functional/app/AppKernelShared.php
@@ -1,0 +1,36 @@
+<?php
+namespace Payum\Bundle\PayumBundle\Tests\Functional\app;
+
+use Payum;
+use Symfony;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\HttpKernel\Kernel;
+
+class AppKernelShared extends Kernel
+{
+    public function registerBundles(): array
+    {
+        $bundles = array(
+            new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+            new Symfony\Bundle\TwigBundle\TwigBundle(),
+            new Payum\Bundle\PayumBundle\PayumBundle(),
+        );
+
+        return $bundles;
+    }
+
+    public function getCacheDir(): string
+    {
+        return sys_get_temp_dir() . '/PayumBundle/cache';
+    }
+
+    public function getLogDir(): string
+    {
+        return sys_get_temp_dir() . '/PayumBundle/logs';
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader): void
+    {
+        $loader->load(__DIR__ . '/config/config.yml');
+    }
+}

--- a/Tests/Functional/app/AppKernelShared.php
+++ b/Tests/Functional/app/AppKernelShared.php
@@ -32,5 +32,13 @@ class AppKernelShared extends Kernel
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(__DIR__ . '/config/config.yml');
+
+        if(Kernel::MAJOR_VERSION===4){
+            $loader->load(__DIR__ . '/config/config_sf4.yml');
+        }
+        else
+        {
+            $loader->load(__DIR__ . '/config/config_sf5.yml');
+        }
     }
 }

--- a/Tests/Functional/app/config/config.yml
+++ b/Tests/Functional/app/config/config.yml
@@ -7,9 +7,12 @@ framework:
     #translator:      { fallback: %locale% }
     test: ~
     session:
-        storage_id: 'session.storage.mock_file'
+        handler_id: null
+        cookie_secure: auto
+        cookie_samesite: lax
+        storage_factory_id: session.storage.factory.mock_file
     secret:          '%secret%'
-    router:          { resource: '%kernel.project_dir%/Tests/Functional/app/config/routing.yml' }
+    router:          { utf8: true, resource: '%kernel.project_dir%/Tests/Functional/app/config/routing.yml' }
     default_locale:  '%locale%'
     form:                                                 true
     csrf_protection:                                      true

--- a/Tests/Functional/app/config/config.yml
+++ b/Tests/Functional/app/config/config.yml
@@ -13,7 +13,7 @@ framework:
     default_locale:  '%locale%'
     form:                                                 true
     csrf_protection:                                      true
-    validation:                                           { enable_annotations: true }
+    validation:                                           { enable_annotations: false }
     assets: false
 
 payum:

--- a/Tests/Functional/app/config/config.yml
+++ b/Tests/Functional/app/config/config.yml
@@ -11,7 +11,6 @@ framework:
     default_locale:  '%locale%'
     form:                                                 true
     csrf_protection:                                      true
-    #validation:                                           { enable_annotations: false }
     assets: false
 
 payum:

--- a/Tests/Functional/app/config/config.yml
+++ b/Tests/Functional/app/config/config.yml
@@ -6,17 +6,12 @@ framework:
     #esi:             ~
     #translator:      { fallback: %locale% }
     test: ~
-    session:
-        handler_id: null
-        cookie_secure: auto
-        cookie_samesite: lax
-        storage_factory_id: session.storage.factory.mock_file
     secret:          '%secret%'
     router:          { utf8: true, resource: '%kernel.project_dir%/Tests/Functional/app/config/routing.yml' }
     default_locale:  '%locale%'
     form:                                                 true
     csrf_protection:                                      true
-    validation:                                           { enable_annotations: false }
+    #validation:                                           { enable_annotations: false }
     assets: false
 
 payum:

--- a/Tests/Functional/app/config/config_sf4.yml
+++ b/Tests/Functional/app/config/config_sf4.yml
@@ -1,0 +1,4 @@
+framework:
+  session:
+    storage_id: 'session.storage.mock_file'
+  validation: { enable_annotations: true }

--- a/Tests/Functional/app/config/config_sf5.yml
+++ b/Tests/Functional/app/config/config_sf5.yml
@@ -1,0 +1,7 @@
+framework:
+    session:
+        handler_id: null
+        cookie_secure: auto
+        cookie_samesite: lax
+        storage_factory_id: session.storage.factory.mock_file
+    validation: { enable_annotations: false }

--- a/Tests/PayumBundleTest.php
+++ b/Tests/PayumBundleTest.php
@@ -9,7 +9,7 @@ class PayumBundleTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function shouldBeSubClassOfBundle()
+    public function shouldBeSubClassOfBundle(): void
     {
         $rc = new \ReflectionClass(PayumBundle::class);
 
@@ -19,8 +19,9 @@ class PayumBundleTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function couldBeConstructedWithoutAnyArguments()
+    public function couldBeConstructedWithoutAnyArguments(): void
     {
+        $this->expectNotToPerformAssertions();
         new PayumBundle;
     }
 } 

--- a/Tests/Sonata/GatewayConfigAdminTest.php
+++ b/Tests/Sonata/GatewayConfigAdminTest.php
@@ -16,7 +16,7 @@ class GatewayConfigAdminTest extends TestCase
     /**
      * @test
      */
-    public function shouldBeSubClassSonataAdmin()
+    public function shouldBeSubClassSonataAdmin(): void
     {
         $rc = new \ReflectionClass(GatewayConfigAdmin::class);
 
@@ -26,7 +26,7 @@ class GatewayConfigAdminTest extends TestCase
     /**
      * @test
      */
-    public function couldBeConstructedWithExpectedArguments()
+    public function couldBeConstructedWithExpectedArguments(): void
     {
         new GatewayConfigAdmin('code', 'class', 'baseControllerName');
     }
@@ -34,7 +34,7 @@ class GatewayConfigAdminTest extends TestCase
     /**
      * @test
      */
-    public function shouldAllowSetFormFactory()
+    public function shouldAllowSetFormFactory(): void
     {
         $admin = new GatewayConfigAdmin('code', 'class', 'baseControllerName');
 

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "defuse/php-encryption": "^2",
         "doctrine/orm": "~2.5",
         "payum/omnipay-v3-bridge": "^1@alpha",
-        "payum/payum": "^1.6",
+        "payum/payum": "^1.6.2",
         "php-http/guzzle6-adapter": "1.1.1",
         "omnipay/dummy": "^3@alpha",
         "omnipay/paypal": "^3@dev",

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "php": "^7.4 || ^8.0",
         "payum/core": "^1.6",
         "symfony/framework-bundle": "^4.4 || ^5.0",
-        "symfony/form": "^4.4 || ^5.0",
+        "symfony/form": "^4.4.20 || ^5.0",
         "symfony/validator": "^4.4 || ^5.0",
         "symfony/security-csrf": "^4.4 | ^5.0"
     },
@@ -50,7 +50,7 @@
         "symfony/twig-bundle": "^4.4|^5",
         "symfony/expression-language": "^4.4 || ^5.0",
         "symfony/browser-kit": "^4.4 || ^5.0",
-        "symfony/phpunit-bridge": "^4.4 || ^5.0",
+        "symfony/phpunit-bridge": "6.0",
         "symfony/templating": "^4.4 || ^5.0",
         "symfony/yaml": "^4.4 || ^5.0 ",
         "defuse/php-encryption": "^2",

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         }
     ],
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "payum/core": "^1.6",
         "symfony/framework-bundle": "^4.4 || ^5.0",
         "symfony/form": "^4.4 || ^5.0",
@@ -45,7 +45,7 @@
         "symfony/security-csrf": "^4.4 | ^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.5 || ^8.5",
+        "phpunit/phpunit": "^9.5",
         "twig/twig": "^1.16 || ^2.0 || ^3.0",
         "symfony/twig-bundle": "^4.4|^5",
         "symfony/expression-language": "^4.4 || ^5.0",

--- a/composer.json
+++ b/composer.json
@@ -65,8 +65,8 @@
         "klarna/checkout": "~1|~2.0",
         "fp/klarna-invoice": "0.1.*",
         "stripe/stripe-php": "~1.0",
-        "league/uri-schemes": "^1.1",
         "doctrine/annotations": "^1.9",
+        "psr/log": "^2",
         "ext-curl": "*",
         "ext-pdo_sqlite": "*",
         "ext-soap": "*"

--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
         "fp/klarna-invoice": "0.1.*",
         "stripe/stripe-php": "~1.0",
         "doctrine/annotations": "^1.9",
-        "psr/log": "^2",
+        "psr/log": "^1 || ^2",
         "ext-curl": "*",
         "ext-pdo_sqlite": "*",
         "ext-soap": "*"


### PR DESCRIPTION
All Changes are related to php 7.4 and phpunit 9 and to get tests running.
This PR is related to https://github.com/Payum/PayumBundle/pull/535

Serveral changes are needed in composer.json
"league/uri-schemes": "^1.1",  => Otherwise it would not install on php 8.x
"payum/payum": "^1.6.2", => Otherwise --prefer-lowest Test will not be an installable set
"symfony/phpunit-bridge": "6.0", => Only one version is needed for require-dev
"psr/log": "^1 || ^2", is more a temporary fix. I guesss the real problem is in payum itself. https://github.com/Payum/Payum/pull/926
"symfony/form": "^4.4.20 || ^5.0", => Required for the test (Annotated Validations) CreditCardTypeTest->shouldRequireExpireAtInFuture()

Update: All Tests are migrated to phpUnit 9.

Symfony4 needs some extra config to work with Symfony4, 5 and 6 in the near future.
Symfony6 will need extra Work, as there are deprecated functions.
Should be handled in an different PR, after support of Symfony6 is added.