### PR TITLE
feat: php 7.4 features and typehints

### DIFF
--- a/Command/CreateCaptureTokenCommand.php
+++ b/Command/CreateCaptureTokenCommand.php
@@ -16,13 +16,6 @@ class CreateCaptureTokenCommand extends Command implements ContainerAwareInterfa
     use ContainerAwareTrait;
 
     protected static $defaultName = 'payum:security:create-capture-token';
-    protected Payum $payum;
-
-    public function __construct(Payum $payum)
-    {
-        $this->payum = $payum;
-        parent::__construct();
-    }
 
     /**
      * {@inheritDoc}
@@ -50,7 +43,7 @@ class CreateCaptureTokenCommand extends Command implements ContainerAwareInterfa
 
         $model = null;
         if ($modelClass && $modelId) {
-            if (false == $model = $this->payum->getStorage($modelClass)->find($modelId)) {
+            if (false == $model = $this->getPayum()->getStorage($modelClass)->find($modelId)) {
                 throw new RuntimeException(sprintf(
                     'Cannot find model with class %s and id %s.',
                     $modelClass,
@@ -59,7 +52,7 @@ class CreateCaptureTokenCommand extends Command implements ContainerAwareInterfa
             }
         }
 
-        $token = $this->payum->getTokenFactory()->createCaptureToken($gatewayName, $model, $afterUrl);
+        $token = $this->getPayum()->getTokenFactory()->createCaptureToken($gatewayName, $model, $afterUrl);
 
         $output->writeln(sprintf('Hash: <info>%s</info>', $token->getHash()));
         $output->writeln(sprintf('Url: <info>%s</info>', $token->getTargetUrl()));
@@ -67,5 +60,13 @@ class CreateCaptureTokenCommand extends Command implements ContainerAwareInterfa
         $output->writeln(sprintf('Details: <info>%s</info>', (string) $token->getDetails()));
 
         return 0;
+    }
+
+    /**
+     * @return Payum
+     */
+    protected function getPayum()
+    {
+        return $this->container->get('payum');
     }
 }

--- a/Command/CreateCaptureTokenCommand.php
+++ b/Command/CreateCaptureTokenCommand.php
@@ -16,11 +16,18 @@ class CreateCaptureTokenCommand extends Command implements ContainerAwareInterfa
     use ContainerAwareTrait;
 
     protected static $defaultName = 'payum:security:create-capture-token';
+    protected Payum $payum;
+
+    public function __construct(Payum $payum)
+    {
+        $this->payum = $payum;
+        parent::__construct();
+    }
 
     /**
      * {@inheritDoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName(static::$defaultName)
@@ -34,7 +41,7 @@ class CreateCaptureTokenCommand extends Command implements ContainerAwareInterfa
     /**
      * {@inheritDoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $gatewayName = $input->getArgument('gateway-name');
         $modelClass = $input->getOption('model-class');
@@ -43,7 +50,7 @@ class CreateCaptureTokenCommand extends Command implements ContainerAwareInterfa
 
         $model = null;
         if ($modelClass && $modelId) {
-            if (false == $model = $this->getPayum()->getStorage($modelClass)->find($modelId)) {
+            if (false == $model = $this->payum->getStorage($modelClass)->find($modelId)) {
                 throw new RuntimeException(sprintf(
                     'Cannot find model with class %s and id %s.',
                     $modelClass,
@@ -52,7 +59,7 @@ class CreateCaptureTokenCommand extends Command implements ContainerAwareInterfa
             }
         }
 
-        $token = $this->getPayum()->getTokenFactory()->createCaptureToken($gatewayName, $model, $afterUrl);
+        $token = $this->payum->getTokenFactory()->createCaptureToken($gatewayName, $model, $afterUrl);
 
         $output->writeln(sprintf('Hash: <info>%s</info>', $token->getHash()));
         $output->writeln(sprintf('Url: <info>%s</info>', $token->getTargetUrl()));
@@ -60,13 +67,5 @@ class CreateCaptureTokenCommand extends Command implements ContainerAwareInterfa
         $output->writeln(sprintf('Details: <info>%s</info>', (string) $token->getDetails()));
 
         return 0;
-    }
-
-    /**
-     * @return Payum
-     */
-    protected function getPayum()
-    {
-        return $this->container->get('payum');
     }
 }

--- a/Command/CreateNotifyTokenCommand.php
+++ b/Command/CreateNotifyTokenCommand.php
@@ -16,13 +16,6 @@ class CreateNotifyTokenCommand extends Command implements ContainerAwareInterfac
     use ContainerAwareTrait;
 
     protected static $defaultName = 'payum:security:create-notify-token';
-    protected Payum $payum;
-
-    public function __construct(Payum $payum)
-    {
-        $this->payum = $payum;
-        parent::__construct();
-    }
 
     /**
      * {@inheritDoc}
@@ -48,7 +41,7 @@ class CreateNotifyTokenCommand extends Command implements ContainerAwareInterfac
         $model = null;
 
         if ($modelClass && $modelId) {
-            if (false == $model = $this->payum->getStorage($modelClass)->find($modelId)) {
+            if (false == $model = $this->getPayum()->getStorage($modelClass)->find($modelId)) {
                 throw new RuntimeException(sprintf(
                     'Cannot find model with class %s and id %s.',
                     $modelClass,
@@ -57,12 +50,20 @@ class CreateNotifyTokenCommand extends Command implements ContainerAwareInterfac
             }
         }
 
-        $token = $this->payum->getTokenFactory()->createNotifyToken($gatewayName, $model);
+        $token = $this->getPayum()->getTokenFactory()->createNotifyToken($gatewayName, $model);
 
         $output->writeln(sprintf('Hash: <info>%s</info>', $token->getHash()));
         $output->writeln(sprintf('Url: <info>%s</info>', $token->getTargetUrl()));
         $output->writeln(sprintf('Details: <info>%s</info>', (string) $token->getDetails() ?: 'null'));
 
         return 0;
+    }
+
+    /**
+     * @return Payum
+     */
+    protected function getPayum()
+    {
+        return $this->container->get('payum');
     }
 }

--- a/Command/CreateNotifyTokenCommand.php
+++ b/Command/CreateNotifyTokenCommand.php
@@ -16,11 +16,18 @@ class CreateNotifyTokenCommand extends Command implements ContainerAwareInterfac
     use ContainerAwareTrait;
 
     protected static $defaultName = 'payum:security:create-notify-token';
+    protected Payum $payum;
+
+    public function __construct(Payum $payum)
+    {
+        $this->payum = $payum;
+        parent::__construct();
+    }
 
     /**
      * {@inheritDoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName(static::$defaultName)
@@ -33,7 +40,7 @@ class CreateNotifyTokenCommand extends Command implements ContainerAwareInterfac
     /**
      * {@inheritDoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $gatewayName = $input->getArgument('gateway-name');
         $modelClass = $input->getOption('model-class');
@@ -41,7 +48,7 @@ class CreateNotifyTokenCommand extends Command implements ContainerAwareInterfac
         $model = null;
 
         if ($modelClass && $modelId) {
-            if (false == $model = $this->getPayum()->getStorage($modelClass)->find($modelId)) {
+            if (false == $model = $this->payum->getStorage($modelClass)->find($modelId)) {
                 throw new RuntimeException(sprintf(
                     'Cannot find model with class %s and id %s.',
                     $modelClass,
@@ -50,20 +57,12 @@ class CreateNotifyTokenCommand extends Command implements ContainerAwareInterfac
             }
         }
 
-        $token = $this->getPayum()->getTokenFactory()->createNotifyToken($gatewayName, $model);
+        $token = $this->payum->getTokenFactory()->createNotifyToken($gatewayName, $model);
 
         $output->writeln(sprintf('Hash: <info>%s</info>', $token->getHash()));
         $output->writeln(sprintf('Url: <info>%s</info>', $token->getTargetUrl()));
         $output->writeln(sprintf('Details: <info>%s</info>', (string) $token->getDetails() ?: 'null'));
 
         return 0;
-    }
-
-    /**
-     * @return Payum
-     */
-    protected function getPayum()
-    {
-        return $this->container->get('payum');
     }
 }

--- a/Controller/AuthorizeController.php
+++ b/Controller/AuthorizeController.php
@@ -2,11 +2,12 @@
 namespace Payum\Bundle\PayumBundle\Controller;
 
 use Payum\Core\Request\Authorize;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 
 class AuthorizeController extends PayumController
 {
-    public function doAction(Request $request)
+    public function doAction(Request $request): RedirectResponse
     {
         $token = $this->getPayum()->getHttpRequestVerifier()->verify($request);
 

--- a/Controller/CancelController.php
+++ b/Controller/CancelController.php
@@ -2,17 +2,15 @@
 namespace Payum\Bundle\PayumBundle\Controller;
 
 use Payum\Core\Request\Cancel;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class CancelController extends PayumController
 {
     /**
-     * @return RedirectResponse|Response
      * @throws \Exception
      */
-    public function doAction(Request $request)
+    public function doAction(Request $request): Response
     {
         $token = $this->getPayum()->getHttpRequestVerifier()->verify($request);
 

--- a/Controller/CancelController.php
+++ b/Controller/CancelController.php
@@ -2,11 +2,16 @@
 namespace Payum\Bundle\PayumBundle\Controller;
 
 use Payum\Core\Request\Cancel;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class CancelController extends PayumController
 {
+    /**
+     * @return RedirectResponse|Response
+     * @throws \Exception
+     */
     public function doAction(Request $request)
     {
         $token = $this->getPayum()->getHttpRequestVerifier()->verify($request);

--- a/Controller/CaptureController.php
+++ b/Controller/CaptureController.php
@@ -3,12 +3,13 @@ namespace Payum\Bundle\PayumBundle\Controller;
 
 use Payum\Core\Reply\HttpPostRedirect;
 use Payum\Core\Request\Capture;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class CaptureController extends PayumController
 {
-    public function doSessionTokenAction(Request $request)
+    public function doSessionTokenAction(Request $request): RedirectResponse
     {
         if (false === $request->hasSession()) {
             throw new HttpException(400, 'This controller requires session to be started.');
@@ -34,7 +35,7 @@ class CaptureController extends PayumController
         return $this->redirect($redirectUrl);
     }
 
-    public function doAction(Request $request)
+    public function doAction(Request $request): RedirectResponse
     {
         $token = $this->getPayum()->getHttpRequestVerifier()->verify($request);
 

--- a/Controller/NotifyController.php
+++ b/Controller/NotifyController.php
@@ -7,7 +7,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 class NotifyController extends PayumController
 {
-    public function doUnsafeAction(Request $request)
+    public function doUnsafeAction(Request $request): Response
     {
         $gateway = $this->getPayum()->getGateway($request->get('gateway'));
 
@@ -16,7 +16,7 @@ class NotifyController extends PayumController
         return new Response('', 204);
     }
 
-    public function doAction(Request $request)
+    public function doAction(Request $request): Response
     {
         $token = $this->getPayum()->getHttpRequestVerifier()->verify($request);
 

--- a/Controller/PayoutController.php
+++ b/Controller/PayoutController.php
@@ -2,12 +2,12 @@
 namespace Payum\Bundle\PayumBundle\Controller;
 
 use Payum\Core\Request\Payout;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class PayoutController extends PayumController
 {
-    public function doAction(Request $request)
+    public function doAction(Request $request): RedirectResponse
     {
         $token = $this->getPayum()->getHttpRequestVerifier()->verify($request);
 

--- a/Controller/PayumController.php
+++ b/Controller/PayumController.php
@@ -8,15 +8,19 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 
 abstract class PayumController extends AbstractController
 {
-    /**
-     * @return Payum
-     */
-    protected function getPayum()
+    protected Payum $payum;
+
+    public function __construct(Payum $payum)
     {
-        return $this->get('payum');
+        $this->payum = $payum;
     }
 
-    public static function getSubscribedServices()
+    protected function getPayum(): Payum
+    {
+        return $this->payum;
+    }
+
+    public static function getSubscribedServices(): array
     {
         return array_merge(parent::getSubscribedServices(), [
             'payum' => Payum::class,
@@ -25,20 +29,16 @@ abstract class PayumController extends AbstractController
 
     /**
      * @deprecated will be removed in 2.0.
-     *
-     * @return HttpRequestVerifierInterface
      */
-    protected function getHttpRequestVerifier()
+    protected function getHttpRequestVerifier(): HttpRequestVerifierInterface
     {
         return $this->getPayum()->getHttpRequestVerifier();
     }
 
     /**
      * @deprecated will be removed in 2.0.
-     *
-     * @return GenericTokenFactoryInterface
      */
-    protected function getTokenFactory()
+    protected function getTokenFactory(): GenericTokenFactoryInterface
     {
         return $this->getPayum()->getTokenFactory();
     }

--- a/Controller/PayumController.php
+++ b/Controller/PayumController.php
@@ -8,19 +8,16 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 
 abstract class PayumController extends AbstractController
 {
-    protected Payum $payum;
-
-    public function __construct(Payum $payum)
+    /**
+     * @return Payum
+     */
+    protected function getPayum()
     {
-        $this->payum = $payum;
+        return $this->get('payum');
     }
 
-    protected function getPayum(): Payum
-    {
-        return $this->payum;
-    }
-
-    public static function getSubscribedServices(): array
+    /** @return string[] */
+    public static function getSubscribedServices()
     {
         return array_merge(parent::getSubscribedServices(), [
             'payum' => Payum::class,
@@ -29,16 +26,20 @@ abstract class PayumController extends AbstractController
 
     /**
      * @deprecated will be removed in 2.0.
+     *
+     * @return HttpRequestVerifierInterface
      */
-    protected function getHttpRequestVerifier(): HttpRequestVerifierInterface
+    protected function getHttpRequestVerifier()
     {
         return $this->getPayum()->getHttpRequestVerifier();
     }
 
     /**
      * @deprecated will be removed in 2.0.
+     *
+     * @return GenericTokenFactoryInterface
      */
-    protected function getTokenFactory(): GenericTokenFactoryInterface
+    protected function getTokenFactory()
     {
         return $this->getPayum()->getTokenFactory();
     }

--- a/Controller/RefundController.php
+++ b/Controller/RefundController.php
@@ -2,17 +2,15 @@
 namespace Payum\Bundle\PayumBundle\Controller;
 
 use Payum\Core\Request\Refund;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class RefundController extends PayumController
 {
     /**
-     * @return RedirectResponse|Response
      * @throws \Exception
      */
-    public function doAction(Request $request)
+    public function doAction(Request $request): Response
     {
         $token = $this->getPayum()->getHttpRequestVerifier()->verify($request);
 

--- a/Controller/RefundController.php
+++ b/Controller/RefundController.php
@@ -2,11 +2,16 @@
 namespace Payum\Bundle\PayumBundle\Controller;
 
 use Payum\Core\Request\Refund;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class RefundController extends PayumController
 {
+    /**
+     * @return RedirectResponse|Response
+     * @throws \Exception
+     */
     public function doAction(Request $request)
     {
         $token = $this->getPayum()->getHttpRequestVerifier()->verify($request);

--- a/Controller/SyncController.php
+++ b/Controller/SyncController.php
@@ -2,11 +2,12 @@
 namespace Payum\Bundle\PayumBundle\Controller;
 
 use Payum\Core\Request\Sync;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 
 class SyncController extends PayumController
 {
-    public function doAction(Request $request)
+    public function doAction(Request $request): RedirectResponse
     {
         $token = $this->getPayum()->getHttpRequestVerifier()->verify($request);
 

--- a/DependencyInjection/Compiler/BuildConfigsPass.php
+++ b/DependencyInjection/Compiler/BuildConfigsPass.php
@@ -9,7 +9,7 @@ class BuildConfigsPass implements CompilerPassInterface
     /**
      * {@inheritDoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $configs = $this->processTagData($container->findTaggedServiceIds('payum.action'), 'payum.action.', 'payum.prepend_actions');
         $configs = array_replace_recursive(
@@ -41,7 +41,7 @@ class BuildConfigsPass implements CompilerPassInterface
         }
     }
 
-    protected function processTagData(array $tagData, $namePrefix, $prependKey)
+    protected function processTagData(array $tagData, $namePrefix, $prependKey): array
     {
         $coreGatewayFactoryConfig = [];
         $gatewaysFactoriesConfigs = [];
@@ -49,6 +49,7 @@ class BuildConfigsPass implements CompilerPassInterface
 
         foreach ($tagData as $serviceId => $tagAttributes) {
             foreach ($tagAttributes as $attributes) {
+                /** @noinspection SlowArrayOperationsInLoopInspection */
                 $attributes = array_replace(['alias' => null, 'factory' => null, 'gateway' => null,  'all' => false, 'prepend' => false], $attributes);
 
                 $name = $attributes['alias'] ?: $serviceId;
@@ -62,6 +63,7 @@ class BuildConfigsPass implements CompilerPassInterface
                             $coreGatewayFactoryConfig[$prependKey] = [];
                         }
 
+                        /** @noinspection UnsupportedStringOffsetOperationsInspection */
                         $coreGatewayFactoryConfig[$prependKey][] = $name;
                     }
                 } elseif ($attributes['factory']) {

--- a/DependencyInjection/Compiler/BuildGatewayFactoriesBuilderPass.php
+++ b/DependencyInjection/Compiler/BuildGatewayFactoriesBuilderPass.php
@@ -11,7 +11,7 @@ class BuildGatewayFactoriesBuilderPass implements CompilerPassInterface
     /**
      * {@inheritDoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $builder = $container->getDefinition('payum.builder');
         foreach ($container->findTaggedServiceIds('payum.gateway_factory_builder') as $serviceId => $tagAttributes) {

--- a/DependencyInjection/Compiler/BuildGatewayFactoriesPass.php
+++ b/DependencyInjection/Compiler/BuildGatewayFactoriesPass.php
@@ -11,7 +11,7 @@ class BuildGatewayFactoriesPass implements CompilerPassInterface
     /**
      * {@inheritDoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $registry = $container->getDefinition('payum.static_registry');
 

--- a/DependencyInjection/Compiler/BuildGatewaysPass.php
+++ b/DependencyInjection/Compiler/BuildGatewaysPass.php
@@ -10,7 +10,7 @@ class BuildGatewaysPass implements CompilerPassInterface
     /**
      * {@inheritDoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $registry = $container->getDefinition('payum.static_registry');
 

--- a/DependencyInjection/Compiler/BuildStoragesPass.php
+++ b/DependencyInjection/Compiler/BuildStoragesPass.php
@@ -10,7 +10,7 @@ class BuildStoragesPass implements CompilerPassInterface
     /**
      * {@inheritDoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $registry = $container->getDefinition('payum.static_registry');
 

--- a/DependencyInjection/MainConfiguration.php
+++ b/DependencyInjection/MainConfiguration.php
@@ -12,7 +12,7 @@ class MainConfiguration implements ConfigurationInterface
     /**
      * @var StorageFactoryInterface[]
      */
-    protected $storageFactories = array();
+    protected array $storageFactories = array();
 
     /**
      * @param StorageFactoryInterface[] $storageFactories
@@ -27,7 +27,7 @@ class MainConfiguration implements ConfigurationInterface
     /**
      * {@inheritDoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $tb = new TreeBuilder('payum');
         $rootNode = $tb->getRootNode();
@@ -55,10 +55,7 @@ class MainConfiguration implements ConfigurationInterface
         return $tb;
     }
 
-    /**
-     * @param ArrayNodeDefinition $rootPrototypeNode
-     */
-    protected function addStoragesSection(ArrayNodeDefinition $rootPrototypeNode)
+    protected function addStoragesSection(ArrayNodeDefinition $rootPrototypeNode): void
     {
         $storageNode = $rootPrototypeNode->children()
                 ->arrayNode('storages')
@@ -127,10 +124,7 @@ class MainConfiguration implements ConfigurationInterface
         }
     }
 
-    /**
-     * @param ArrayNodeDefinition $securityNode
-     */
-    protected function addSecuritySection(ArrayNodeDefinition $securityNode)
+    protected function addSecuritySection(ArrayNodeDefinition $securityNode): void
     {
         $storageNode = $securityNode->children()
             ->arrayNode('token_storage')
@@ -186,10 +180,7 @@ class MainConfiguration implements ConfigurationInterface
         }
     }
 
-    /**
-     * @param ArrayNodeDefinition $dynamicGatewaysNode
-     */
-    protected function addDynamicGatewaysSection(ArrayNodeDefinition $dynamicGatewaysNode)
+    protected function addDynamicGatewaysSection(ArrayNodeDefinition $dynamicGatewaysNode): void
     {
         $dynamicGatewaysNode->children()
             ->booleanNode('sonata_admin')->defaultFalse()

--- a/DependencyInjection/PayumExtension.php
+++ b/DependencyInjection/PayumExtension.php
@@ -30,12 +30,12 @@ class PayumExtension extends Extension implements PrependExtensionInterface
     /**
      * @var StorageFactoryInterface[]
      */
-    protected $storagesFactories = array();
+    protected array $storagesFactories = array();
 
     /**
      * {@inheritDoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $this->addStorageFactory(new FilesystemStorageFactory);
         $this->addStorageFactory(new DoctrineStorageFactory);
@@ -61,20 +61,20 @@ class PayumExtension extends Extension implements PrependExtensionInterface
         $this->loadStorages($config['storages'], $container);
         $this->loadSecurity($config['security'], $container);
 
-        $this->loadCoreGateway(isset($config['gateways']['core']) ? $config['gateways']['core'] : [], $container);
+        $this->loadCoreGateway($config['gateways']['core'] ?? [], $container);
         unset($config['gateways']['core']);
 
         $this->loadGateways($config['gateways'], $container);
 
         if (isset($config['dynamic_gateways'])) {
             $this->loadDynamicGateways($config['dynamic_gateways'], $container);
-        };
+        }
     }
 
     /**
      * {@inheritDoc}
      */
-    public function prepend(ContainerBuilder $container)
+    public function prepend(ContainerBuilder $container): void
     {
         $bundles = $container->getParameter('kernel.bundles');
 
@@ -102,11 +102,7 @@ class PayumExtension extends Extension implements PrependExtensionInterface
         }
     }
 
-    /**
-     * @param array $config
-     * @param ContainerBuilder $container
-     */
-    protected function loadGateways(array $config, ContainerBuilder $container)
+    protected function loadGateways(array $config, ContainerBuilder $container): void
     {
         $builder = $container->getDefinition('payum.builder');
 
@@ -115,11 +111,7 @@ class PayumExtension extends Extension implements PrependExtensionInterface
         }
     }
 
-    /**
-     * @param array $config
-     * @param ContainerBuilder $container
-     */
-    protected function loadCoreGateway(array $config, ContainerBuilder $container)
+    protected function loadCoreGateway(array $config, ContainerBuilder $container): void
     {
         $builder = $container->getDefinition('payum.builder');
 
@@ -139,11 +131,7 @@ class PayumExtension extends Extension implements PrependExtensionInterface
         $builder->addMethodCall('addCoreGatewayFactoryConfig', [$config]);
     }
 
-    /**
-     * @param array $config
-     * @param ContainerBuilder $container
-     */
-    protected function loadStorages(array $config, ContainerBuilder $container)
+    protected function loadStorages(array $config, ContainerBuilder $container): void
     {
         foreach ($config as $modelClass => $storageConfig) {
             $storageFactoryName = $this->findSelectedStorageFactoryNameInStorageConfig($storageConfig);
@@ -180,11 +168,7 @@ class PayumExtension extends Extension implements PrependExtensionInterface
         }
     }
 
-    /**
-     * @param array $securityConfig
-     * @param ContainerBuilder $container
-     */
-    protected function loadSecurity(array $securityConfig, ContainerBuilder $container)
+    protected function loadSecurity(array $securityConfig, ContainerBuilder $container): void
     {
         foreach ($securityConfig['token_storage'] as $tokenClass => $tokenStorageConfig) {
             $storageFactoryName = $this->findSelectedStorageFactoryNameInStorageConfig($tokenStorageConfig);
@@ -199,11 +183,7 @@ class PayumExtension extends Extension implements PrependExtensionInterface
         }
     }
 
-    /**
-     * @param array $dynamicGatewaysConfig
-     * @param ContainerBuilder $container
-     */
-    protected function loadDynamicGateways(array $dynamicGatewaysConfig, ContainerBuilder $container)
+    protected function loadDynamicGateways(array $dynamicGatewaysConfig, ContainerBuilder $container): void
     {
         $configClass = null;
         $configStorage = null;
@@ -235,7 +215,7 @@ class PayumExtension extends Extension implements PrependExtensionInterface
         }
 
         //deprecated
-        $registry =  new Definition(DynamicRegistry::class, array(
+        $registry = new Definition(DynamicRegistry::class, array(
             new Reference('payum.dynamic_gateways.config_storage'),
             new Reference('payum.static_registry')
         ));
@@ -275,11 +255,9 @@ class PayumExtension extends Extension implements PrependExtensionInterface
     }
 
     /**
-     * @param Factory\Storage\StorageFactoryInterface $factory
-     *
      * @throws \Payum\Core\Exception\InvalidArgumentException
      */
-    public function addStorageFactory(StorageFactoryInterface $factory)
+    public function addStorageFactory(StorageFactoryInterface $factory): void
     {
         $factoryName = $factory->getName();
         if (empty($factoryName)) {
@@ -300,17 +278,14 @@ class PayumExtension extends Extension implements PrependExtensionInterface
         return new MainConfiguration($this->storagesFactories);
     }
 
-    /**
-     * @param array $storageConfig
-     *
-     * @return string
-     */
-    protected function findSelectedStorageFactoryNameInStorageConfig($storageConfig)
+    protected function findSelectedStorageFactoryNameInStorageConfig(array $storageConfig): string
     {
         foreach ($storageConfig as $name => $value) {
             if (isset($this->storagesFactories[$name])) {
                 return $name;
             }
         }
+
+        throw new \RuntimeException('StorageFactoryName not found');
     }
 }

--- a/EventListener/ReplyToHttpResponseListener.php
+++ b/EventListener/ReplyToHttpResponseListener.php
@@ -7,29 +7,22 @@ use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 
 class ReplyToHttpResponseListener
 {
-    /**
-     * @var ReplyToSymfonyResponseConverter
-     */
-    private $replyToSymfonyResponseConverter;
+    private ReplyToSymfonyResponseConverter $replyToSymfonyResponseConverter;
 
-    /**
-     * @param ReplyToSymfonyResponseConverter $replyToSymfonyResponseConverter
-     */
     public function __construct(ReplyToSymfonyResponseConverter $replyToSymfonyResponseConverter)
     {
         $this->replyToSymfonyResponseConverter = $replyToSymfonyResponseConverter;
     }
 
-    /**
-     * @param ExceptionEvent $event
-     */
-    public function onKernelException(ExceptionEvent $event)
+    public function onKernelException(ExceptionEvent $event): void
     {
         if (false === $event->getThrowable() instanceof ReplyInterface) {
             return;
         }
 
-        $response = $this->replyToSymfonyResponseConverter->convert($event->getThrowable());
+        /** @var $throwable ReplyInterface */
+        $throwable = $event->getThrowable();
+        $response = $this->replyToSymfonyResponseConverter->convert($throwable);
 
         $event->allowCustomResponseCode();
 

--- a/Form/Extension/GatewayFactoriesChoiceTypeExtension.php
+++ b/Form/Extension/GatewayFactoriesChoiceTypeExtension.php
@@ -8,14 +8,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class GatewayFactoriesChoiceTypeExtension extends AbstractTypeExtension
 {
-    /**
-     * @var GatewayFactoryRegistryInterface
-     */
-    private $gatewayFactoryRegistry;
+    private GatewayFactoryRegistryInterface $gatewayFactoryRegistry;
 
-    /**
-     * @param GatewayFactoryRegistryInterface $gatewayFactoryRegistry
-     */
     public function __construct(GatewayFactoryRegistryInterface $gatewayFactoryRegistry)
     {
         $this->gatewayFactoryRegistry = $gatewayFactoryRegistry;
@@ -24,7 +18,7 @@ class GatewayFactoriesChoiceTypeExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $options = $resolver->getDefinedOptions();
         if (empty($options['choices'])) {
@@ -41,10 +35,7 @@ class GatewayFactoriesChoiceTypeExtension extends AbstractTypeExtension
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getExtendedType()
+    public function getExtendedType(): string
     {
         return GatewayFactoriesChoiceType::class;
     }

--- a/PayumBundle.php
+++ b/PayumBundle.php
@@ -11,7 +11,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class PayumBundle extends Bundle
 {
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 

--- a/Profiler/PayumCollector.php
+++ b/Profiler/PayumCollector.php
@@ -13,7 +13,7 @@ class PayumCollector extends DataCollector implements ExtensionInterface
     /**
      * @var Context[]
      */
-    private $contexts = [];
+    private array $contexts = [];
 
     /**
      * @var array
@@ -23,7 +23,7 @@ class PayumCollector extends DataCollector implements ExtensionInterface
     /**
      * {@inheritdoc}
      */
-    public function collect(Request $request, Response $response, \Throwable $exception = null)
+    public function collect(Request $request, Response $response, \Throwable $exception = null): void
     {
         foreach ($this->contexts as $context) {
             $request = $context->getRequest();
@@ -76,7 +76,7 @@ class PayumCollector extends DataCollector implements ExtensionInterface
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return 'payum';
     }
@@ -84,7 +84,7 @@ class PayumCollector extends DataCollector implements ExtensionInterface
     /**
      * {@inheritdoc}
      */
-    public function onPreExecute(Context $context)
+    public function onPreExecute(Context $context): void
     {
         $this->contexts[] = $context;
     }
@@ -92,28 +92,23 @@ class PayumCollector extends DataCollector implements ExtensionInterface
     /**
      * {@inheritdoc}
      */
-    public function onExecute(Context $context)
+    public function onExecute(Context $context): void
     {
     }
 
     /**
      * {@inheritdoc}
      */
-    public function onPostExecute(Context $context)
+    public function onPostExecute(Context $context): void
     {
     }
 
-    /**
-     * @param object $object
-     *
-     * @return string
-     */
-    private function getShortClass($object)
+    private function getShortClass(object $object): string
     {
         return (new \ReflectionClass($object))->getShortName();
     }
 
-    public function dump()
+    public function dump(): string
     {
         $str = '';
         $previousContext = null;
@@ -141,13 +136,13 @@ class PayumCollector extends DataCollector implements ExtensionInterface
         return $str;
     }
 
-    public function reset()
+    public function reset(): void
     {
         $this->contexts = [];
         $this->data = [];
     }
 
-    protected function formatAction(array $contextData)
+    protected function formatAction(array $contextData): string
     {
         return sprintf(
             '%s└ %s::execute(%s)',
@@ -157,29 +152,25 @@ class PayumCollector extends DataCollector implements ExtensionInterface
         );
     }
 
-    protected function formatReply(array $contextData)
+    protected function formatReply(array $contextData): string
     {
-        $str = sprintf(
+        return sprintf(
             '%s reply %s',
             sprintf('%s ⬅', str_repeat(' ', $contextData['deep'])),
             $contextData['reply_short_class']
         );
-
-        return $str;
     }
 
-    protected function formatException(array $contextData)
+    protected function formatException(array $contextData): string
     {
-        $str = sprintf(
+        return sprintf(
             '%s exception %s',
             sprintf('%s ⬅', str_repeat(' ', $contextData['deep'])),
             $contextData['exception_short_class']
         );
-
-        return $str;
     }
 
-    protected function formatRequest(array $contextData)
+    protected function formatRequest(array $contextData): string
     {
         return sprintf(
             '%s[%s]',

--- a/Sonata/GatewayConfigAdmin.php
+++ b/Sonata/GatewayConfigAdmin.php
@@ -6,33 +6,21 @@ use Payum\Core\Security\CypherInterface;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
+use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Payum\Core\Bridge\Symfony\Form\Type\GatewayConfigType;
 
 class GatewayConfigAdmin extends AbstractAdmin
 {
-    /**
-     * @var FormFactoryInterface
-     */
-    protected $formFactory;
+    protected FormFactoryInterface $formFactory;
+    protected ?CypherInterface $cypher;
 
-    /**
-     * @var CypherInterface|null
-     */
-    protected $cypher;
-
-    /**
-     * @param FormFactoryInterface $formFactory
-     */
-    public function setFormFactory(FormFactoryInterface $formFactory)
+    public function setFormFactory(FormFactoryInterface $formFactory): void
     {
         $this->formFactory = $formFactory;
     }
 
-    /**
-     * @param CypherInterface $cypher
-     */
-    public function setCypher(CypherInterface $cypher)
+    public function setCypher(CypherInterface $cypher): void
     {
         $this->cypher = $cypher;
     }
@@ -40,7 +28,7 @@ class GatewayConfigAdmin extends AbstractAdmin
     /**
      * {@inheritdoc}
      */
-    protected function configureFormFields(FormMapper $form)
+    protected function configureFormFields(FormMapper $form): void
     {
         $form->reorder(array()); //hack!
     }
@@ -48,7 +36,7 @@ class GatewayConfigAdmin extends AbstractAdmin
     /**
      * {@inheritDoc}
      */
-    protected function configureListFields(ListMapper $list)
+    protected function configureListFields(ListMapper $list): void
     {
         $list
             ->add('gatewayName')
@@ -66,7 +54,7 @@ class GatewayConfigAdmin extends AbstractAdmin
     /**
      * {@inheritdoc}
      */
-    public function preUpdate($object)
+    public function preUpdate($object): void
     {
         parent::preUpdate($object);
 
@@ -78,7 +66,7 @@ class GatewayConfigAdmin extends AbstractAdmin
     /**
      * {@inheritdoc}
      */
-    public function prePersist($object)
+    public function prePersist($object): void
     {
         parent::prePersist($object);
 
@@ -104,7 +92,7 @@ class GatewayConfigAdmin extends AbstractAdmin
     /**
      * {@inheritDoc}
      */
-    public function getFormBuilder()
+    public function getFormBuilder(): FormBuilderInterface
     {
         $formBuilder = $this->formFactory->createBuilder(GatewayConfigType::class, $this->getSubject(), array(
             'data_class' => get_class($this->getSubject()),


### PR DESCRIPTION
Add php 7.4 features.
Add typehints
Remove wrong (According to PhpStorm) and useless DocBlocks Comments

DI for Payum (container->get() is deprecated and removed in Symfony 6). 
**This needs to be tested.** But tests do not work correct.
Payum\Core\Payum vs Payum\Core\Registry\RegistryInterface in Commands? See old DocBlock return hints.
So this should be merged upfront https://github.com/Payum/PayumBundle/pull/536