### PR TITLE
feat: add typehints for factories

### DIFF
--- a/DependencyInjection/Factory/Storage/AbstractStorageFactory.php
+++ b/DependencyInjection/Factory/Storage/AbstractStorageFactory.php
@@ -10,7 +10,7 @@ abstract class AbstractStorageFactory implements StorageFactoryInterface
     /**
      * {@inheritDoc}
      */
-    public function create(ContainerBuilder $container, $modelClass, array $config)
+    public function create(ContainerBuilder $container, $modelClass, array $config): string
     {
         $storageId = sprintf('payum.storage.%s', strtolower(str_replace(array('\\\\', '\\'), '_', $modelClass)));
 
@@ -22,19 +22,9 @@ abstract class AbstractStorageFactory implements StorageFactoryInterface
         return $storageId;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function addConfiguration(ArrayNodeDefinition $builder)
+    public function addConfiguration(ArrayNodeDefinition $builder): void
     {
     }
 
-    /**
-     * @param ContainerBuilder $container
-     * @param string $modelClass
-     * @param array $config
-     *
-     * @return Definition
-     */
-    abstract protected function createStorage(ContainerBuilder $container, $modelClass, array $config);
+    abstract protected function createStorage(ContainerBuilder $container, string $modelClass, array $config): Definition;
 }

--- a/DependencyInjection/Factory/Storage/CustomStorageFactory.php
+++ b/DependencyInjection/Factory/Storage/CustomStorageFactory.php
@@ -10,23 +10,17 @@ class CustomStorageFactory extends AbstractStorageFactory
     /**
      * {@inheritDoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return 'custom';
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function createStorage(ContainerBuilder $container, $modelClass, array $config)
+    protected function createStorage(ContainerBuilder $container, string $modelClass, array $config): ChildDefinition
     {
         return new ChildDefinition($config['service']);
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function addConfiguration(ArrayNodeDefinition $builder)
+    public function addConfiguration(ArrayNodeDefinition $builder): void
     {
         parent::addConfiguration($builder);
 

--- a/DependencyInjection/Factory/Storage/DoctrineStorageFactory.php
+++ b/DependencyInjection/Factory/Storage/DoctrineStorageFactory.php
@@ -12,15 +12,12 @@ class DoctrineStorageFactory extends AbstractStorageFactory
     /**
      * {@inheritDoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return 'doctrine';
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function addConfiguration(ArrayNodeDefinition $builder)
+    public function addConfiguration(ArrayNodeDefinition $builder): void
     {
         parent::addConfiguration($builder);
         
@@ -33,10 +30,7 @@ class DoctrineStorageFactory extends AbstractStorageFactory
             ->end();
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    protected function createStorage(ContainerBuilder $container, $modelClass, array $config)
+    protected function createStorage(ContainerBuilder $container, string $modelClass, array $config): ChildDefinition
     {
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../../../Resources/config/storage'));
         $loader->load('doctrine.'.$config['driver'].'.xml');

--- a/DependencyInjection/Factory/Storage/FilesystemStorageFactory.php
+++ b/DependencyInjection/Factory/Storage/FilesystemStorageFactory.php
@@ -12,15 +12,12 @@ class FilesystemStorageFactory extends AbstractStorageFactory
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return 'filesystem';
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function addConfiguration(ArrayNodeDefinition $builder)
+    public function addConfiguration(ArrayNodeDefinition $builder): void
     {
         parent::addConfiguration($builder);
         
@@ -30,10 +27,7 @@ class FilesystemStorageFactory extends AbstractStorageFactory
         ->end();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function createStorage(ContainerBuilder $container, $modelClass, array $config)
+    protected function createStorage(ContainerBuilder $container, string $modelClass, array $config): ChildDefinition
     {
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../../../Resources/config/storage'));
         $loader->load('filesystem.xml');

--- a/DependencyInjection/Factory/Storage/Propel1StorageFactory.php
+++ b/DependencyInjection/Factory/Storage/Propel1StorageFactory.php
@@ -1,29 +1,22 @@
 <?php
-
 namespace Payum\Bundle\PayumBundle\DependencyInjection\Factory\Storage;
-
 
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\Config\FileLocator;
 
-
-class Propel1StorageFactory  extends AbstractStorageFactory
+class Propel1StorageFactory extends AbstractStorageFactory
 {
-    
     /**
      * {@inheritDoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return "propel1";
     }
-        
-    /**
-     * {@inheritDoc}
-     */
-    protected function createStorage(ContainerBuilder $container, $modelClass, array $config)
+
+    protected function createStorage(ContainerBuilder $container, string $modelClass, array $config): ChildDefinition
     {
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../../../Resources/config/storage'));
         $loader->load('propel1.xml');

--- a/DependencyInjection/Factory/Storage/Propel2StorageFactory.php
+++ b/DependencyInjection/Factory/Storage/Propel2StorageFactory.php
@@ -1,29 +1,22 @@
 <?php
-
 namespace Payum\Bundle\PayumBundle\DependencyInjection\Factory\Storage;
-
 
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\Config\FileLocator;
 
-
 class Propel2StorageFactory  extends AbstractStorageFactory
 {
-    
     /**
      * {@inheritDoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return "propel2";
     }
-    
-    /**
-     * {@inheritDoc}
-     */
-    protected function createStorage(ContainerBuilder $container, $modelClass, array $config)
+
+    protected function createStorage(ContainerBuilder $container, string $modelClass, array $config): ChildDefinition
     {
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../../../Resources/config/storage'));
         $loader->load('propel2.xml');

--- a/DependencyInjection/Factory/Storage/StorageFactoryInterface.php
+++ b/DependencyInjection/Factory/Storage/StorageFactoryInterface.php
@@ -7,25 +7,20 @@ use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 interface StorageFactoryInterface
 {
     /**
-     * @param ContainerBuilder $container
      * @param string $modelClass
-     * @param array $config
-     *
      * @return string The payment serviceId
      */
     function create(ContainerBuilder $container, $modelClass, array $config);
 
     /**
-     * The storage name, 
+     * The storage name,
      * For example filesystem, doctrine, propel etc.
-     * 
+     *
      * @return string
      */
     function getName();
 
     /**
-     * @param ArrayNodeDefinition $builder
-     * 
      * @return void
      */
     function addConfiguration(ArrayNodeDefinition $builder);


### PR DESCRIPTION
Needs review and testing. See https://github.com/Payum/PayumBundle/pull/536
Could be BC Break if User extend these factories.
The interface is not changed.

Can someone explain the background why in the Interface the ReturnTypes are not set, and `$modelClass` is not TypeHinted with `string` in the past?