### PR TITLE
fix: symfony/phpunit-bridge version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "symfony/twig-bundle": "^4.4|^5",
         "symfony/expression-language": "^4.4 || ^5.0",
         "symfony/browser-kit": "^4.4 || ^5.0",
-        "symfony/phpunit-bridge": "6.0",
+        "symfony/phpunit-bridge": "^6.0",
         "symfony/templating": "^4.4 || ^5.0",
         "symfony/yaml": "^4.4 || ^5.0 ",
         "defuse/php-encryption": "^2",


### PR DESCRIPTION
i missed the `^` in one of my last PRs. Sorry