### PR TITLE
feat: clean up README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,29 +2,28 @@
 
 Payum is an MIT-licensed open source project with its ongoing development made possible entirely by the support of community and our customers. If you'd like to join them, please consider:
 
-- [Become a sponsor](https://www.patreon.com/makasim)
-- [Become our client](http://forma-pro.com/)
+- [Become our client](https://forma-pro.com/)
 
 ---
 
 # PayumBundle 
 [![Gitter](https://badges.gitter.im/Payum/Payum.svg)](https://gitter.im/Payum/Payum?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
-[![Build Status](https://travis-ci.org/Payum/PayumBundle.png?branch=master)](https://travis-ci.org/Payum/PayumBundle) 
+[![Build Status](https://github.com/Payum/PayumBundle/actions/workflows/tests.yaml/badge.svg)](https://github.com/Payum/PayumBundle/actions/workflows/tests.yaml)
 [![Total Downloads](https://poser.pugx.org/payum/payum-bundle/d/total.png)](https://packagist.org/packages/payum/payum-bundle) 
 [![Latest Stable Version](https://poser.pugx.org/payum/payum-bundle/version.png)](https://packagist.org/packages/payum/payum-bundle)
 
-The bundle  integrate [payum](https://github.com/Payum/Payum) into [symfony](http://www.symfony.com) framework.
+The bundle  integrate [payum](https://github.com/Payum/Payum) into [symfony](https://symfony.com/) framework.
 It already supports [+35 gateways](https://github.com/Payum/Payum/blob/master/docs/supported-gateways.md).
 Provide nice configuration layer, secured capture controller, storages integration and lots of more features.
 
-[Sylius e-commerce platform](http://sylius.org) base its payment solutions on top of the bundle.
+[Sylius, an open source headless eCommerce platform](https://sylius.com/), base its payment solutions on top of the bundle.
 
 ## Resources
 
 * [Site](https://payum.forma-pro.com/)
 * [Documentation](https://github.com/Payum/Payum/blob/master/docs/index.md#symfony-payum-bundle)
 * [Sandbox](https://github.com/makasim/PayumBundleSandbox)
-* [Questions](http://stackoverflow.com/questions/tagged/payum)
+* [Questions](https://stackoverflow.com/questions/tagged/payum)
 * [Issue Tracker](https://github.com/Payum/PayumBundle/issues)
 * [Twitter](https://twitter.com/payumphp)
 
@@ -107,11 +106,7 @@ PayumBundle is an open source, community-driven project. Pull requests are very 
 
 ## Like it? Spread the word!
 
-Star PayumBundle on [github](https://github.com/Payum/PayumBundle) or [packagist](https://packagist.org/packages/payum/payum-bundle).
-
-## Donate
-
-<a href='https://pledgie.com/campaigns/30526'><img alt='Click here to lend your support to: Your private payment processing server. Setup it once and rule them all and make a donation at pledgie.com !' src='https://pledgie.com/campaigns/30526.png?skin_name=chrome' border='0' ></a>
+Star PayumBundle on [GitHub](https://github.com/Payum/PayumBundle) or [packagist](https://packagist.org/packages/payum/payum-bundle).
 
 ## License
 


### PR DESCRIPTION
Change links to http, correct links.

If i see this correct, it is not possible to donate to @makasim on patreon anymore.
Can you confirm this?

Change badge to GitHub.

Removed link to Pledgie.
The website has been discontinued in January 2018.[[3]](https://en.wikipedia.org/wiki/Pledgie#cite_note-3)

Twitter and Gitter are a bit outdated, but mabye still useful.

The Sandbox should be modernized (i will try to have a look at this) or removed from the readme.
https://github.com/makasim/PayumBundleSandbox