### PR TITLE
add ci tests for php8.2, bump github action versions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Get composer cache directory
         id: composercache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
         uses: actions/cache@v3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,10 +32,12 @@ jobs:
             symfony: 6.0.*
           - php: 8.1
             symfony: 6.1.*
+          - php: 8.2
+            symfony: 6.2.*
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -48,7 +50,7 @@ jobs:
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composercache.outputs.dir }}
           key: ${{ runner.os }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json composer.lock') }}
@@ -59,8 +61,8 @@ jobs:
 
       - name: Install Symfony Flex
         run: |
-          composer require symfony/flex:^1 --no-update
           composer config --no-plugins allow-plugins.symfony/flex true
+          composer require symfony/flex:"^1|^2" --no-update
 
       - name: Install dependencies
         run: composer update


### PR DESCRIPTION
Allow symfony/flex:"^1|^2"

Fix deprecation of `set-output`
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/