### PR TITLE
Add storages when constructing extension

### DIFF
--- a/DependencyInjection/PayumExtension.php
+++ b/DependencyInjection/PayumExtension.php
@@ -32,11 +32,9 @@ class PayumExtension extends Extension implements PrependExtensionInterface
      * @var StorageFactoryInterface[]
      */
     protected array $storagesFactories = array();
-    
+
     public function __construct()
     {
-        parent::__construct();
-
         $this->addStorageFactory(new FilesystemStorageFactory);
         $this->addStorageFactory(new DoctrineStorageFactory);
         $this->addStorageFactory(new CustomStorageFactory);

--- a/DependencyInjection/PayumExtension.php
+++ b/DependencyInjection/PayumExtension.php
@@ -32,18 +32,23 @@ class PayumExtension extends Extension implements PrependExtensionInterface
      * @var StorageFactoryInterface[]
      */
     protected array $storagesFactories = array();
+    
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->addStorageFactory(new FilesystemStorageFactory);
+        $this->addStorageFactory(new DoctrineStorageFactory);
+        $this->addStorageFactory(new CustomStorageFactory);
+        $this->addStorageFactory(new Propel1StorageFactory);
+        $this->addStorageFactory(new Propel2StorageFactory);
+    }
 
     /**
      * {@inheritDoc}
      */
     public function load(array $configs, ContainerBuilder $container): void
     {
-        $this->addStorageFactory(new FilesystemStorageFactory);
-        $this->addStorageFactory(new DoctrineStorageFactory);
-        $this->addStorageFactory(new CustomStorageFactory);
-        $this->addStorageFactory(new Propel1StorageFactory);
-        $this->addStorageFactory(new Propel2StorageFactory);
-
         $mainConfig = $this->getConfiguration($configs, $container);
 
         $config = $this->processConfiguration($mainConfig, $configs);


### PR DESCRIPTION
Add storage factories when constructing the container extension, to be compatible with [Symfony's Config Builders](https://symfony.com/blog/new-in-symfony-5-3-config-builder-classes). Without this change, the config builder doesn't recognise the storage configs.