### PR TITLE
Fixed the ordering of method procerss, that mothod that loads all ext…

### DIFF
--- a/DependencyInjection/Compiler/BuildConfigsPass.php
+++ b/DependencyInjection/Compiler/BuildConfigsPass.php
@@ -23,12 +23,6 @@ class BuildConfigsPass implements CompilerPassInterface
         );
 
         $builder = $container->getDefinition('payum.builder');
-        if ($container->hasDefinition('twig')) {
-            $config = ['twig.env' => new Reference('twig')];
-
-            $builder->addMethodCall('addCoreGatewayFactoryConfig', [$config]);
-        }
-
         if (false === empty($configs[0])) {
             $builder->addMethodCall('addCoreGatewayFactoryConfig', [$configs[0]]);
         }
@@ -39,6 +33,12 @@ class BuildConfigsPass implements CompilerPassInterface
 
         foreach ($configs[2] as $gatewayName => $gatewayConfig) {
             $builder->addMethodCall('addGateway', [$gatewayName, $gatewayConfig]);
+        }
+
+        if ($container->hasDefinition('twig')) {
+            $config = ['twig.env' => new Reference('twig')];
+
+            $builder->addMethodCall('addCoreGatewayFactoryConfig', [$config]);
         }
     }
 


### PR DESCRIPTION
…ensions into config for the Payum Bundle to function correctly.

The empty config passed for twig.env replaced the $currentConfig(already set config to only the twig config) at array_replace_recursive Thus the other extensions that needs to be added to the config gets chuckedm as they are not in the $currentConfig anymore. The method addCoreGatewayFactoryConfig changed here  https://github.com/Payum/Core/commit/f444c4cf8466679d775c8e6caa73eaf161cc338d
 - This changed to recursivly relae the $currentConfig and twig.enc config being a small config with nothing else in it, it just discards the $cyrrentConfig ad no other config can be added. - 

> _**This was a premature assessment on my behalf, it turned out to be a complex Twig issue, where our app has many Twig overloadds and custom extensions.**_ 