### PR TITLE
[Profiler/PayumCollector.php] Fix deprecated message

### DIFF
--- a/Profiler/PayumCollector.php
+++ b/Profiler/PayumCollector.php
@@ -19,7 +19,7 @@ class PayumCollector extends DataCollector implements ExtensionInterface
     /**
      * {@inheritdoc}
      */
-    public function collect(Request $request, Response $response, \Throwable $exception = null): void
+    public function collect(Request $request, Response $response, ?\Throwable $exception = null): void
     {
         foreach ($this->contexts as $context) {
             $request = $context->getRequest();


### PR DESCRIPTION
Explicitly define $exception parameter for function collect() as a nullable or Throwable.

> Deprecated: Payum\Bundle\PayumBundle\Profiler\PayumCollector::collect(): Implicitly marking parameter $exception as nullable is deprecated, the explicit nullable type must be used instead

