### PR TITLE
Resolve deprecation on Symfony 5.4

### DIFF
--- a/Traits/ControllerTrait.php
+++ b/Traits/ControllerTrait.php
@@ -20,6 +20,9 @@ if (Kernel::MAJOR_VERSION >= 6 ) {
 } else {
     trait ControllerTrait
     {
+        /**
+         * @return array<string, class-string>
+         */
         public static function getSubscribedServices()
         {
             return array_merge(parent::getSubscribedServices(), [


### PR DESCRIPTION
Add a @return phpdoc to silence deprecation notice on Symfony 5.4

> Method "Symfony\Contracts\Service\ServiceSubscriberInterface::getSubscribedServices()" might add "array" as a native return type declaration in the future. Do the same in implementation "Payum\Bundle\PayumBundle\Controller\PayumController" now to avoid errors or add an explicit @return annotation to suppress this message.