### PR TITLE
Add support for Payum 2.0

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,7 +7,7 @@ env:
 
 jobs:
   unit-test:
-    name: Unit ( PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }} )
+    name: Unit ( PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, Payum ${{ matrix.payum || '1.x' }} )
     runs-on: ubuntu-latest
 
     strategy:
@@ -36,6 +36,13 @@ jobs:
             symfony: 7.0.*
           - php: 8.5
             symfony: 8.0.*
+          # payum/core 2.x, where a gateway is built with a dependency injection container
+          - php: 8.2
+            symfony: 6.4.*
+            payum: 2.x
+          - php: 8.4
+            symfony: 7.0.*
+            payum: 2.x
 
     steps:
       - name: Checkout
@@ -65,6 +72,14 @@ jobs:
         run: |
           composer config --no-plugins allow-plugins.symfony/flex true
           composer require symfony/flex:"^1|^2" --no-update
+
+      - name: Install Payum 2.x
+        if: matrix.payum == '2.x'
+        # the sub packages are part of the payum/payum monorepo from 2.0 on, so they cannot be
+        # installed next to it
+        run: |
+          composer remove --dev --no-update payum/offline payum/stripe payum/paypal-express-checkout-nvp payum/omnipay-v3-bridge omnipay/common omnipay/dummy omnipay/paypal
+          composer require --dev --no-update payum/payum:2.x-dev
 
       - name: Install dependencies
         run: composer update --prefer-source

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -77,7 +77,14 @@ jobs:
         if: matrix.payum == '2.x'
         # the sub packages are part of the payum/payum monorepo from 2.0 on, so they cannot be
         # installed next to it
+        #
+        # 2.x-dev is a branch rather than a release, so the commit behind it moves without the
+        # constraint moving with it. The cache is keyed on composer.json alone - composer.lock is not
+        # committed - so a restored cache holds the branch at whichever commit it resolved to when
+        # that cache was written, and the job silently tests against a payum/core from hours or days
+        # ago. Dropping the cache costs one download and is what keeps the branch current.
         run: |
+          composer clear-cache
           composer remove --dev --no-update payum/offline payum/stripe payum/paypal-express-checkout-nvp payum/omnipay-v3-bridge omnipay/common omnipay/dummy omnipay/paypal
           composer require --dev --no-update payum/payum:2.x-dev
 

--- a/Builder/PayumCoreGatewayFactoryBuilder.php
+++ b/Builder/PayumCoreGatewayFactoryBuilder.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Bundle\PayumBundle\Builder;
+
+use Payum\Bundle\PayumBundle\PayumCoreGatewayFactory;
+use function call_user_func_array;
+use function func_get_args;
+
+/**
+ * Builds the core gateway factory of the bundle for payum/core 2.0 and later.
+ *
+ * Unlike its 1.x counterpart it does not need the container: services reach the factory as real
+ * references resolved while the container is built, rather than as "@id" strings resolved at runtime.
+ */
+class PayumCoreGatewayFactoryBuilder
+{
+    public function __invoke()
+    {
+        return call_user_func_array([$this, 'build'], func_get_args());
+    }
+
+    public function build(array $defaultConfig): PayumCoreGatewayFactory
+    {
+        return new PayumCoreGatewayFactory($defaultConfig);
+    }
+}

--- a/DI/SymfonyContainerAdapter.php
+++ b/DI/SymfonyContainerAdapter.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Bundle\PayumBundle\DI;
+
+use Payum\Core\DI\ListableContainerInterface;
+use Psr\Container\ContainerInterface;
+use Symfony\Contracts\Service\ServiceProviderInterface;
+use function array_keys;
+use function interface_exists;
+
+/**
+ * Payum's global container, backed by the services of the application.
+ *
+ * Payum is handed a service locator rather than the whole Symfony container: it only ever sees the
+ * services the bundle decided to share, so a lookup of a service Payum defines itself is not
+ * accidentally answered by an unrelated service of the application which happens to have the same id.
+ *
+ * Reporting the entries of the locator is what makes those services injectable into the constructor of
+ * a gateway action - Payum can only turn services it knows the ids of into definitions of the gateway
+ * containers. That is what ListableContainerInterface is for. It only exists from payum/core 2.0.1
+ * onwards, which is why the class is declared twice below: with an older 2.x the services are still
+ * resolvable from a gateway, they just cannot be autowired.
+ */
+trait SymfonyContainerAdapterTrait
+{
+    public function __construct(
+        private ServiceProviderInterface $locator
+    ) {
+    }
+
+    public function get(string $id): mixed
+    {
+        return $this->locator->get($id);
+    }
+
+    public function has(string $id): bool
+    {
+        return $this->locator->has($id);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getKnownEntryNames(): array
+    {
+        return array_keys($this->locator->getProvidedServices());
+    }
+}
+
+if (interface_exists(ListableContainerInterface::class)) {
+    final class SymfonyContainerAdapter implements ListableContainerInterface
+    {
+        use SymfonyContainerAdapterTrait;
+    }
+} else {
+    final class SymfonyContainerAdapter implements ContainerInterface
+    {
+        use SymfonyContainerAdapterTrait;
+    }
+}

--- a/DependencyInjection/Compiler/BuildConfigsPass.php
+++ b/DependencyInjection/Compiler/BuildConfigsPass.php
@@ -1,6 +1,8 @@
 <?php
 namespace Payum\Bundle\PayumBundle\DependencyInjection\Compiler;
 
+use Payum\Bundle\PayumBundle\PayumCoreGatewayFactory;
+use Payum\Bundle\PayumBundle\PayumVersion;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -12,15 +14,9 @@ class BuildConfigsPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container): void
     {
-        $configs = $this->processTagData($container->findTaggedServiceIds('payum.action'), 'payum.action.', 'payum.prepend_actions');
-        $configs = array_replace_recursive(
-            $configs,
-            $this->processTagData($container->findTaggedServiceIds('payum.api'), 'payum.api.', 'payum.prepend_apis')
-        );
-        $configs = array_replace_recursive(
-            $configs,
-            $this->processTagData($container->findTaggedServiceIds('payum.extension'), 'payum.extension.', 'payum.prepend_extensions')
-        );
+        $configs = PayumVersion::supportsDependencyInjection() ?
+            $this->buildContainerEntries($container) :
+            $this->buildLegacyConfig($container);
 
         $builder = $container->getDefinition('payum.builder');
         if ($container->hasDefinition('twig')) {
@@ -40,6 +36,92 @@ class BuildConfigsPass implements CompilerPassInterface
         foreach ($configs[2] as $gatewayName => $gatewayConfig) {
             $builder->addMethodCall('addGateway', [$gatewayName, $gatewayConfig]);
         }
+    }
+
+    /**
+     * The tagged services as configuration entries of payum/core 1.x, where a service is referred to by
+     * an "@id" string which ContainerAwareCoreGatewayFactory resolves at runtime.
+     *
+     * @return array{0: array<string, mixed>, 1: array<string, array<string, mixed>>, 2: array<string, array<string, mixed>>}
+     */
+    protected function buildLegacyConfig(ContainerBuilder $container): array
+    {
+        $configs = $this->processTagData($container->findTaggedServiceIds('payum.action'), 'payum.action.', 'payum.prepend_actions');
+        $configs = array_replace_recursive(
+            $configs,
+            $this->processTagData($container->findTaggedServiceIds('payum.api'), 'payum.api.', 'payum.prepend_apis')
+        );
+
+        return array_replace_recursive(
+            $configs,
+            $this->processTagData($container->findTaggedServiceIds('payum.extension'), 'payum.extension.', 'payum.prepend_extensions')
+        );
+    }
+
+    /**
+     * The tagged services as entries of the gateway containers of payum/core 2.0 and later, where a
+     * service is a real reference resolved while the container is built.
+     *
+     * @return array{0: array<string, mixed>, 1: array<string, array<string, mixed>>, 2: array<string, array<string, mixed>>}
+     */
+    protected function buildContainerEntries(ContainerBuilder $container): array
+    {
+        $configs = $this->processTagDataForContainer(
+            $container->findTaggedServiceIds('payum.action'),
+            PayumCoreGatewayFactory::SHARED_ACTIONS,
+            PayumCoreGatewayFactory::ACTIONS
+        );
+        $configs = array_replace_recursive(
+            $configs,
+            $this->processTagDataForContainer(
+                $container->findTaggedServiceIds('payum.api'),
+                PayumCoreGatewayFactory::SHARED_APIS,
+                PayumCoreGatewayFactory::APIS
+            )
+        );
+
+        return array_replace_recursive(
+            $configs,
+            $this->processTagDataForContainer(
+                $container->findTaggedServiceIds('payum.extension'),
+                PayumCoreGatewayFactory::SHARED_EXTENSIONS,
+                PayumCoreGatewayFactory::EXTENSIONS
+            )
+        );
+    }
+
+    /**
+     * @param array<string, list<array<string, mixed>>> $tagData
+     *
+     * @return array{0: array<string, mixed>, 1: array<string, array<string, mixed>>, 2: array<string, array<string, mixed>>}
+     */
+    protected function processTagDataForContainer(array $tagData, string $sharedKey, string $scopedKey): array
+    {
+        $coreGatewayFactoryConfig = [];
+        $gatewaysFactoriesConfigs = [];
+        $gatewaysConfigs = [];
+
+        foreach ($tagData as $serviceId => $tagAttributes) {
+            foreach ($tagAttributes as $attributes) {
+                /** @noinspection SlowArrayOperationsInLoopInspection */
+                $attributes = array_replace(['alias' => null, 'factory' => null, 'gateway' => null,  'all' => false, 'prepend' => false], $attributes);
+
+                $entry = [
+                    'service' => new Reference($serviceId),
+                    'prepend' => (bool) $attributes['prepend'],
+                ];
+
+                if ($attributes['all']) {
+                    $coreGatewayFactoryConfig[$sharedKey][] = $entry;
+                } elseif ($attributes['factory']) {
+                    $gatewaysFactoriesConfigs[$attributes['factory']][$scopedKey][] = $entry;
+                } elseif ($attributes['gateway']) {
+                    $gatewaysConfigs[$attributes['gateway']][$scopedKey][] = $entry;
+                }
+            }
+        }
+
+        return [$coreGatewayFactoryConfig, $gatewaysFactoriesConfigs, $gatewaysConfigs];
     }
 
     protected function processTagData(array $tagData, string $namePrefix, string $prependKey): array

--- a/DependencyInjection/Compiler/BuildGlobalContainerPass.php
+++ b/DependencyInjection/Compiler/BuildGlobalContainerPass.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Bundle\PayumBundle\DependencyInjection\Compiler;
+
+use Payum\Bundle\PayumBundle\PayumVersion;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Twig\Environment;
+
+/**
+ * Collects the services of the application Payum is allowed to see.
+ *
+ * They end up in a service locator handed to Payum as its global container, which means two things:
+ * a gateway can ask for them, and they can be injected into the constructor of an action.
+ *
+ * Besides a handful of services of the framework, any service tagged payum.global_service is shared.
+ * The tag takes an optional id attribute for the name Payum should know the service under, which is
+ * how a service gets shared under the interface an action type-hints:
+ *
+ *     App\Payment\ExchangeRates:
+ *         tags:
+ *             - { name: payum.global_service, id: App\Payment\ExchangeRatesInterface }
+ *
+ * Only runs with payum/core 2.0 and later - 1.x has no notion of a global container.
+ */
+class BuildGlobalContainerPass implements CompilerPassInterface
+{
+    /**
+     * Services of the framework which are shared when the application has them.
+     */
+    private const FRAMEWORK_SERVICES = [
+        LoggerInterface::class => 'logger',
+        UrlGeneratorInterface::class => 'router',
+        EventDispatcherInterface::class => 'event_dispatcher',
+        Environment::class => 'twig',
+    ];
+
+    public function process(ContainerBuilder $container): void
+    {
+        if (! PayumVersion::supportsDependencyInjection()) {
+            return;
+        }
+
+        if (! $container->hasDefinition('payum.di.global_container')) {
+            return;
+        }
+
+        $services = [];
+
+        foreach (self::FRAMEWORK_SERVICES as $id => $serviceId) {
+            if ($container->has($serviceId)) {
+                $services[$id] = new Reference($serviceId);
+            }
+        }
+
+        foreach ($container->findTaggedServiceIds('payum.global_service') as $serviceId => $tagAttributes) {
+            foreach ($tagAttributes as $attributes) {
+                $services[$attributes['id'] ?? $serviceId] = new Reference($serviceId);
+            }
+        }
+
+        $container->getDefinition('payum.di.global_container')
+            ->replaceArgument(0, ServiceLocatorTagPass::register($container, $services))
+        ;
+    }
+}

--- a/DependencyInjection/PayumExtension.php
+++ b/DependencyInjection/PayumExtension.php
@@ -1,6 +1,7 @@
 <?php
 namespace Payum\Bundle\PayumBundle\DependencyInjection;
 
+use Payum\Bundle\PayumBundle\PayumVersion;
 use Payum\Bundle\PayumBundle\Sonata\GatewayConfigAdmin;
 use Payum\Core\Bridge\Defuse\Security\DefuseCypher;
 use Payum\Bundle\PayumBundle\ReplyToSymfonyResponseConverter;
@@ -12,6 +13,8 @@ use Payum\Core\Registry\DynamicRegistry;
 use Payum\Core\Storage\CryptoStorageDecorator;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -54,6 +57,7 @@ class PayumExtension extends Extension implements PrependExtensionInterface
         // load services
         $loader = new PhpFileLoader($container, new FileLocator(dirname(__DIR__).'/Resources/config'));
         $loader->load('payum.php');
+        $loader->load(PayumVersion::supportsDependencyInjection() ? 'payum_v2.php' : 'payum_v1.php');
         $loader->load('commands.php');
         $loader->load('controller.php');
         $loader->load('form.php');
@@ -127,8 +131,16 @@ class PayumExtension extends Extension implements PrependExtensionInterface
             ],
 
             'payum.action.get_http_request' => new Reference('payum.action.get_http_request'),
-            'payum.action.obtain_credit_card' => new Reference('payum.action.obtain_credit_card_builder'),
         ];
+
+        if (PayumVersion::supportsDependencyInjection()) {
+            // The action is built by PayumCoreGatewayFactory, which takes the template from the
+            // configuration of the gateway it builds rather than from a single service.
+            $defaultConfig[FormFactoryInterface::class] = new Reference('form.factory');
+            $defaultConfig[RequestStack::class] = new Reference('request_stack');
+        } else {
+            $defaultConfig['payum.action.obtain_credit_card'] = new Reference('payum.action.obtain_credit_card_builder');
+        }
 
         $config = array_replace_recursive($defaultConfig, $config);
 

--- a/PayumBundle.php
+++ b/PayumBundle.php
@@ -3,6 +3,7 @@ namespace Payum\Bundle\PayumBundle;
 
 use Payum\Bundle\PayumBundle\DependencyInjection\Compiler\BuildConfigsPass;
 use Payum\Bundle\PayumBundle\DependencyInjection\Compiler\BuildGatewayFactoriesBuilderPass;
+use Payum\Bundle\PayumBundle\DependencyInjection\Compiler\BuildGlobalContainerPass;
 use Payum\Bundle\PayumBundle\DependencyInjection\Compiler\BuildGatewayFactoriesPass;
 use Payum\Bundle\PayumBundle\DependencyInjection\Compiler\BuildGatewaysPass;
 use Payum\Bundle\PayumBundle\DependencyInjection\Compiler\BuildStoragesPass;
@@ -20,5 +21,6 @@ class PayumBundle extends Bundle
         $container->addCompilerPass(new BuildStoragesPass);
         $container->addCompilerPass(new BuildGatewayFactoriesPass);
         $container->addCompilerPass(new BuildGatewayFactoriesBuilderPass());
+        $container->addCompilerPass(new BuildGlobalContainerPass());
     }
 }

--- a/PayumCoreGatewayFactory.php
+++ b/PayumCoreGatewayFactory.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Bundle\PayumBundle;
+
+use Payum\Bundle\PayumBundle\Action\ObtainCreditCardAction;
+use Payum\Core\Action\PrependActionInterface;
+use Payum\Core\Bridge\PlainPhp\Action\GetHttpRequestAction;
+use Payum\Core\CoreGatewayFactory;
+use Payum\Core\Extension\PrependExtensionInterface;
+use Payum\Core\Gateway;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use function array_merge;
+use function DI\get;
+use function func_get_args;
+
+/**
+ * The core gateway factory of the bundle, for payum/core 2.0 and later.
+ *
+ * Two things it adds to the core one: the Symfony flavour of the actions the bundle ships, and the
+ * services tagged payum.action, payum.api and payum.extension.
+ *
+ * Those tagged services reach a gateway through its container: BuildConfigsPass puts them in the
+ * configuration of the core gateway factory (the ones tagged with all) and of the gateway or gateway
+ * factory they belong to, from where Payum turns them into entries of the gateway container.
+ *
+ * They are deliberately not named payum.action.<alias> as in payum/core 1.x. Those ids are used by
+ * payum/core itself for the actions it registers, so re-using them would mean registering some of them
+ * twice; and a per-gateway entry replaces a same-named entry of the gateway factory rather than adding
+ * to it, which would make a gateway lose every service tagged with all as soon as it had one of its own.
+ */
+class PayumCoreGatewayFactory extends CoreGatewayFactory
+{
+    /**
+     * Services tagged with all, shared by every gateway.
+     */
+    public const SHARED_ACTIONS = 'payum.bundle.shared_actions';
+
+    public const SHARED_APIS = 'payum.bundle.shared_apis';
+
+    public const SHARED_EXTENSIONS = 'payum.bundle.shared_extensions';
+
+    /**
+     * Services tagged for one gateway or one gateway factory.
+     */
+    public const ACTIONS = 'payum.bundle.actions';
+
+    public const APIS = 'payum.bundle.apis';
+
+    public const EXTENSIONS = 'payum.bundle.extensions';
+
+    public function configureContainer(): array
+    {
+        return array_merge(
+            parent::configureContainer(),
+            [
+                // payum/core looks its actions up by class name. Point the ones the bundle replaces at
+                // the Symfony implementation, so that a gateway gets that one instead.
+                GetHttpRequestAction::class => get('payum.action.get_http_request'),
+
+                'payum.template.obtain_credit_card' => '@PayumSymfonyBridge\\obtainCreditCard.html.twig',
+
+                ObtainCreditCardAction::class => static function (ContainerInterface $container): ObtainCreditCardAction {
+                    $action = new ObtainCreditCardAction(
+                        $container->get(FormFactoryInterface::class),
+                        $container->get('payum.template.obtain_credit_card')
+                    );
+                    $action->setRequestStack($container->get(RequestStack::class));
+
+                    return $action;
+                },
+            ],
+            // whatever the application configured still wins over the definitions above
+            $this->defaultConfig
+        );
+    }
+
+    public function getActions(): array
+    {
+        return array_merge(parent::getActions(), [
+            ObtainCreditCardAction::class,
+        ]);
+    }
+
+    public function createGateway(ContainerInterface $container): Gateway
+    {
+        $gateway = parent::createGateway(...func_get_args());
+
+        foreach ($this->collect($container, self::SHARED_APIS, self::APIS) as [$api, $prepend]) {
+            $gateway->addApi($api, $prepend);
+        }
+
+        foreach ($this->collect($container, self::SHARED_ACTIONS, self::ACTIONS) as [$action, $prepend]) {
+            $gateway->addAction($action, $prepend || $action instanceof PrependActionInterface);
+        }
+
+        foreach ($this->collect($container, self::SHARED_EXTENSIONS, self::EXTENSIONS) as [$extension, $prepend]) {
+            $gateway->addExtension($extension, $prepend || $extension instanceof PrependExtensionInterface);
+        }
+
+        return $gateway;
+    }
+
+    /**
+     * The services of the given entries, as [service, prepend] pairs, in the order they were tagged.
+     *
+     * @return list<array{0: object, 1: bool}>
+     */
+    private function collect(ContainerInterface $container, string ...$ids): array
+    {
+        $services = [];
+
+        foreach ($ids as $id) {
+            if (! $container->has($id)) {
+                continue;
+            }
+
+            /** @var array<array{service: object, prepend?: bool}> $entries */
+            $entries = (array) $container->get($id);
+
+            foreach ($entries as $entry) {
+                if (! isset($entry['service']) || ! is_object($entry['service'])) {
+                    continue;
+                }
+
+                $services[] = [$entry['service'], (bool) ($entry['prepend'] ?? false)];
+            }
+        }
+
+        return $services;
+    }
+}

--- a/PayumVersion.php
+++ b/PayumVersion.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Bundle\PayumBundle;
+
+use Payum\Core\DI\ContainerConfiguration;
+
+/**
+ * Tells which generation of payum/core the bundle is running against.
+ *
+ * The bundle supports both, and wires itself differently for each, so this is asked in a handful of
+ * places: which service configuration to load, how tagged services are handed to a gateway and which
+ * core gateway factory to build.
+ *
+ * The installed version is not read from Composer's metadata on purpose. payum/payum replaces
+ * payum/core, and neither declares a version outside of a release, so a development install reports a
+ * version which says nothing about which APIs are there. The DI interfaces added in 2.0 do.
+ */
+final class PayumVersion
+{
+    /**
+     * Whether payum/core builds its gateways with a dependency injection container, which is the case
+     * from 2.0 onwards.
+     */
+    public static function supportsDependencyInjection(): bool
+    {
+        return interface_exists(ContainerConfiguration::class);
+    }
+}

--- a/Resources/config/payum.php
+++ b/Resources/config/payum.php
@@ -3,9 +3,7 @@
 declare(strict_types=1);
 
 use Payum\Bundle\PayumBundle\Action\GetHttpRequestAction;
-use Payum\Bundle\PayumBundle\Builder\CoreGatewayFactoryBuilder;
 use Payum\Bundle\PayumBundle\Builder\HttpRequestVerifierBuilder;
-use Payum\Bundle\PayumBundle\Builder\ObtainCreditCardActionBuilder;
 use Payum\Bundle\PayumBundle\Builder\TokenFactoryBuilder;
 use Payum\Bundle\PayumBundle\ContainerAwareRegistry;
 use Payum\Bundle\PayumBundle\EventListener\ReplyToHttpResponseListener;
@@ -96,19 +94,6 @@ return static function (ContainerBuilder $container): void {
 
     $container->register('payum.http_request_verifier_builder', HttpRequestVerifierBuilder::class)
         ->setPublic(false)
-    ;
-
-    $container->register('payum.core_gateway_factory_builder', CoreGatewayFactoryBuilder::class)
-        ->setPublic(false)
-        ->setArguments([new Reference('service_container')])
-    ;
-
-    $container->register('payum.action.obtain_credit_card_builder', ObtainCreditCardActionBuilder::class)
-        ->setPublic(true)
-        ->setArguments([
-            new Reference('form.factory'),
-            new Reference('request_stack'),
-        ])
     ;
 
     $container->register('payum.action.get_http_request', GetHttpRequestAction::class)

--- a/Resources/config/payum_v1.php
+++ b/Resources/config/payum_v1.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Payum\Bundle\PayumBundle\Builder\CoreGatewayFactoryBuilder;
+use Payum\Bundle\PayumBundle\Builder\ObtainCreditCardActionBuilder;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * The services which only make sense with payum/core 1.x.
+ *
+ * A gateway is configured there with an array whose values may be "@service" or "%parameter%" strings,
+ * resolved at runtime by ContainerAwareCoreGatewayFactory, which is why both services below need the
+ * container. See payum_v2.php for how the same thing is done from 2.0 onwards.
+ */
+return static function (ContainerBuilder $container): void {
+    $container->register('payum.core_gateway_factory_builder', CoreGatewayFactoryBuilder::class)
+        ->setPublic(false)
+        ->setArguments([new Reference('service_container')])
+    ;
+
+    $container->register('payum.action.obtain_credit_card_builder', ObtainCreditCardActionBuilder::class)
+        ->setPublic(true)
+        ->setArguments([
+            new Reference('form.factory'),
+            new Reference('request_stack'),
+        ])
+    ;
+};

--- a/Resources/config/payum_v2.php
+++ b/Resources/config/payum_v2.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Payum\Bundle\PayumBundle\Builder\PayumCoreGatewayFactoryBuilder;
+use Payum\Bundle\PayumBundle\DI\SymfonyContainerAdapter;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * The services which only make sense with payum/core 2.0 and later.
+ *
+ * From 2.0 on Payum builds every gateway with a dependency injection container of its own, on top of a
+ * global one holding what all gateways share. The application is allowed to provide that global
+ * container, which is what happens here: Payum looks a service up in the services of the application
+ * first and falls back to its own defaults for everything else.
+ *
+ * The services shared this way are collected by BuildGlobalContainerPass, which fills in the locator
+ * argument below once every bundle has had its say.
+ */
+return static function (ContainerBuilder $container): void {
+    $container->register('payum.di.global_container', SymfonyContainerAdapter::class)
+        ->setPublic(false)
+        ->setArguments([
+            null, // service locator - replaced while the container is built
+        ])
+    ;
+
+    $container->register('payum.core_gateway_factory_builder', PayumCoreGatewayFactoryBuilder::class)
+        ->setPublic(false)
+    ;
+
+    $container->getDefinition('payum.builder')
+        ->addMethodCall('setGlobalContainer', [new Reference('payum.di.global_container')])
+    ;
+};

--- a/Tests/DI/SymfonyContainerAdapterTest.php
+++ b/Tests/DI/SymfonyContainerAdapterTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Bundle\PayumBundle\Tests\DI;
+
+use Payum\Bundle\PayumBundle\DI\SymfonyContainerAdapter;
+use Payum\Bundle\PayumBundle\PayumVersion;
+use Payum\Core\DI\ListableContainerInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use ReflectionClass;
+use stdClass;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+
+class SymfonyContainerAdapterTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (! PayumVersion::supportsDependencyInjection()) {
+            $this->markTestSkipped('The global container needs payum/core 2.0 or later.');
+        }
+    }
+
+    public function testShouldImplementContainerInterface(): void
+    {
+        $rc = new ReflectionClass(SymfonyContainerAdapter::class);
+
+        $this->assertTrue($rc->implementsInterface(ContainerInterface::class));
+    }
+
+    public function testShouldImplementListableContainerInterface(): void
+    {
+        if (! interface_exists(ListableContainerInterface::class)) {
+            $this->markTestSkipped('The installed payum/core cannot be told a container lists its entries.');
+        }
+
+        $rc = new ReflectionClass(SymfonyContainerAdapter::class);
+
+        $this->assertTrue($rc->implementsInterface(ListableContainerInterface::class));
+    }
+
+    public function testShouldResolveAServiceOfTheLocator(): void
+    {
+        $service = new stdClass();
+
+        $container = new SymfonyContainerAdapter(new ServiceLocator([
+            'a_service' => static fn (): stdClass => $service,
+        ]));
+
+        $this->assertTrue($container->has('a_service'));
+        $this->assertSame($service, $container->get('a_service'));
+    }
+
+    public function testShouldNotHaveAServiceTheLocatorDoesNotProvide(): void
+    {
+        $container = new SymfonyContainerAdapter(new ServiceLocator([]));
+
+        $this->assertFalse($container->has('a_service'));
+    }
+
+    public function testShouldReportTheEntriesOfTheLocator(): void
+    {
+        $container = new SymfonyContainerAdapter(new ServiceLocator([
+            'a_service' => static fn (): stdClass => new stdClass(),
+            'another_service' => static fn (): stdClass => new stdClass(),
+        ]));
+
+        $this->assertSame(['a_service', 'another_service'], $container->getKnownEntryNames());
+    }
+
+    public function testShouldReportNoEntryForAnEmptyLocator(): void
+    {
+        $container = new SymfonyContainerAdapter(new ServiceLocator([]));
+
+        $this->assertSame([], $container->getKnownEntryNames());
+    }
+}

--- a/Tests/DependencyInjection/Compiler/BuildConfigsPassTest.php
+++ b/Tests/DependencyInjection/Compiler/BuildConfigsPassTest.php
@@ -2,9 +2,12 @@
 namespace Payum\Bundle\PayumBundle\Tests\DependencyInjection\Compiler;
 
 use Payum\Bundle\PayumBundle\DependencyInjection\Compiler\BuildConfigsPass;
+use Payum\Bundle\PayumBundle\PayumCoreGatewayFactory;
+use Payum\Bundle\PayumBundle\PayumVersion;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
 
 class BuildConfigsPassTest extends \PHPUnit\Framework\TestCase
 {
@@ -190,9 +193,84 @@ class BuildConfigsPassTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * The tagged services of payum/core 2.0 and later, as entries of the gateway containers.
+     */
+    public function provideContainerTags(): array
+    {
+        $entry = static fn (bool $prepend = false): array => [[
+            'service' => new Reference('aservice'),
+            'prepend' => $prepend,
+        ]];
+
+        $keys = [
+            'payum.action' => [PayumCoreGatewayFactory::SHARED_ACTIONS, PayumCoreGatewayFactory::ACTIONS],
+            'payum.api' => [PayumCoreGatewayFactory::SHARED_APIS, PayumCoreGatewayFactory::APIS],
+            'payum.extension' => [PayumCoreGatewayFactory::SHARED_EXTENSIONS, PayumCoreGatewayFactory::EXTENSIONS],
+        ];
+
+        $sets = [];
+
+        foreach ($keys as $tag => [$sharedKey, $scopedKey]) {
+            $sets[$tag . ' untagged scope'] = [['name' => $tag], []];
+            $sets[$tag . ' all'] = [['name' => $tag, 'all' => true], [[
+                'addCoreGatewayFactoryConfig',
+                [[$sharedKey => $entry()]],
+            ]]];
+            // an alias no longer names anything: a service is an entry of a list, not a config key
+            $sets[$tag . ' all with alias'] = [['name' => $tag, 'alias' => 'foo', 'all' => true], [[
+                'addCoreGatewayFactoryConfig',
+                [[$sharedKey => $entry()]],
+            ]]];
+            $sets[$tag . ' all prepended'] = [['name' => $tag, 'prepend' => true, 'all' => true], [[
+                'addCoreGatewayFactoryConfig',
+                [[$sharedKey => $entry(true)]],
+            ]]];
+            $sets[$tag . ' for a factory'] = [['name' => $tag, 'factory' => 'fooFactory'], [[
+                'addGatewayFactoryConfig',
+                ['fooFactory', [$scopedKey => $entry()]],
+            ]]];
+            $sets[$tag . ' for a factory prepended'] = [['name' => $tag, 'prepend' => true, 'factory' => 'fooFactory'], [[
+                'addGatewayFactoryConfig',
+                ['fooFactory', [$scopedKey => $entry(true)]],
+            ]]];
+            $sets[$tag . ' for a gateway'] = [['name' => $tag, 'gateway' => 'fooGateway'], [[
+                'addGateway',
+                ['fooGateway', [$scopedKey => $entry()]],
+            ]]];
+            $sets[$tag . ' for a gateway prepended'] = [['name' => $tag, 'prepend' => true, 'gateway' => 'fooGateway'], [[
+                'addGateway',
+                ['fooGateway', [$scopedKey => $entry(true)]],
+            ]]];
+        }
+
+        return $sets;
+    }
+
+    /**
      * @dataProvider provideTags
      */
     public function testShouldAddConfig(array $tagAttributes, $expected): void
+    {
+        if (PayumVersion::supportsDependencyInjection()) {
+            $this->markTestSkipped('The configuration of payum/core 1.x only.');
+        }
+
+        $this->assertSame($expected, $this->processTag($tagAttributes));
+    }
+
+    /**
+     * @dataProvider provideContainerTags
+     */
+    public function testShouldAddContainerEntries(array $tagAttributes, $expected): void
+    {
+        if (! PayumVersion::supportsDependencyInjection()) {
+            $this->markTestSkipped('The configuration of payum/core 2.0 and later only.');
+        }
+
+        $this->assertEquals($expected, $this->processTag($tagAttributes));
+    }
+
+    private function processTag(array $tagAttributes): array
     {
         $tagName = $tagAttributes['name'];
         unset($tagAttributes['name']);
@@ -206,10 +284,8 @@ class BuildConfigsPassTest extends \PHPUnit\Framework\TestCase
         $container->setDefinition('payum.builder', $builder);
         $container->setDefinition('aservice', $service);
 
-        $pass = new BuildConfigsPass();
+        (new BuildConfigsPass())->process($container);
 
-        $pass->process($container);
-
-        $this->assertEquals($expected, $builder->getMethodCalls());
+        return $builder->getMethodCalls();
     }
 }

--- a/Tests/DependencyInjection/Compiler/BuildGlobalContainerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/BuildGlobalContainerPassTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Bundle\PayumBundle\Tests\DependencyInjection\Compiler;
+
+use Payum\Bundle\PayumBundle\DependencyInjection\Compiler\BuildGlobalContainerPass;
+use Payum\Bundle\PayumBundle\DI\SymfonyContainerAdapter;
+use Payum\Bundle\PayumBundle\PayumVersion;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use ReflectionClass;
+use stdClass;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+class BuildGlobalContainerPassTest extends TestCase
+{
+    public function testShouldImplementCompilerPassInterface(): void
+    {
+        $rc = new ReflectionClass(BuildGlobalContainerPass::class);
+
+        $this->assertTrue($rc->implementsInterface(CompilerPassInterface::class));
+    }
+
+    public function testShouldDoNothingWithoutAGlobalContainer(): void
+    {
+        $container = new ContainerBuilder();
+
+        (new BuildGlobalContainerPass())->process($container);
+
+        $this->assertFalse($container->hasDefinition('payum.di.global_container'));
+    }
+
+    public function testShouldShareAServiceOfTheFramework(): void
+    {
+        $this->skipWithoutDependencyInjection();
+
+        $container = $this->buildContainer();
+        $container->setDefinition('logger', new Definition(NullLogger::class));
+
+        (new BuildGlobalContainerPass())->process($container);
+
+        $this->assertArrayHasKey(LoggerInterface::class, $this->providedServices($container));
+    }
+
+    public function testShouldNotShareAServiceOfTheFrameworkTheApplicationDoesNotHave(): void
+    {
+        $this->skipWithoutDependencyInjection();
+
+        $container = $this->buildContainer();
+
+        (new BuildGlobalContainerPass())->process($container);
+
+        $this->assertArrayNotHasKey(LoggerInterface::class, $this->providedServices($container));
+    }
+
+    public function testShouldShareATaggedService(): void
+    {
+        $this->skipWithoutDependencyInjection();
+
+        $container = $this->buildContainer();
+        $container->setDefinition('acme.service', (new Definition(stdClass::class))->addTag('payum.global_service'));
+
+        (new BuildGlobalContainerPass())->process($container);
+
+        $this->assertArrayHasKey('acme.service', $this->providedServices($container));
+    }
+
+    public function testShouldShareATaggedServiceUnderTheGivenId(): void
+    {
+        $this->skipWithoutDependencyInjection();
+
+        $container = $this->buildContainer();
+        $container->setDefinition('acme.service', (new Definition(stdClass::class))->addTag('payum.global_service', [
+            'id' => 'Acme\\ServiceInterface',
+        ]));
+
+        (new BuildGlobalContainerPass())->process($container);
+
+        $services = $this->providedServices($container);
+
+        $this->assertArrayHasKey('Acme\\ServiceInterface', $services);
+        $this->assertArrayNotHasKey('acme.service', $services);
+    }
+
+    private function skipWithoutDependencyInjection(): void
+    {
+        if (! PayumVersion::supportsDependencyInjection()) {
+            $this->markTestSkipped('The global container needs payum/core 2.0 or later.');
+        }
+    }
+
+    private function buildContainer(): ContainerBuilder
+    {
+        $container = new ContainerBuilder();
+        $container->setDefinition('payum.di.global_container', new Definition(SymfonyContainerAdapter::class, [null]));
+
+        return $container;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function providedServices(ContainerBuilder $container): array
+    {
+        $locator = $container->getDefinition('payum.di.global_container')->getArgument(0);
+
+        return $container->getDefinition((string) $locator)->getArgument(0);
+    }
+}

--- a/Tests/DependencyInjection/PayumExtensionTest.php
+++ b/Tests/DependencyInjection/PayumExtensionTest.php
@@ -279,19 +279,19 @@ class PayumExtensionTest extends TestCase
 
         $this->assertTrue($container->hasDefinition('payum.builder'));
 
-        $builder = $container->getDefinition('payum.builder');
-        $calls = $builder->getMethodCalls();
-        $this->assertEquals('addCoreGatewayFactoryConfig', $calls[6][0]);
+        $calls = $container->getDefinition('payum.builder')->getMethodCalls();
 
-        $builder = $container->getDefinition('payum.builder');
-        $calls = $builder->getMethodCalls();
-        $this->assertEquals('addGateway', $calls[7][0]);
-        $this->assertEquals('a_gateway', $calls[7][1][0]);
-        $this->assertEquals(['foo' => 'fooVal'], $calls[7][1][1]);
+        $this->assertNotEmpty(array_filter($calls, static fn (array $call): bool => 'addCoreGatewayFactoryConfig' === $call[0]));
 
-        $this->assertEquals('addGateway', $calls[8][0]);
-        $this->assertEquals('another_gateway', $calls[8][1][0]);
-        $this->assertEquals(['bar' => 'barVal'], $calls[8][1][1]);
+        $addGateway = array_values(array_filter($calls, static fn (array $call): bool => 'addGateway' === $call[0]));
+
+        $this->assertCount(2, $addGateway);
+
+        $this->assertEquals('a_gateway', $addGateway[0][1][0]);
+        $this->assertEquals(['foo' => 'fooVal'], $addGateway[0][1][1]);
+
+        $this->assertEquals('another_gateway', $addGateway[1][1][0]);
+        $this->assertEquals(['bar' => 'barVal'], $addGateway[1][1][1]);
     }
 }
 

--- a/Tests/Functional/Command/DebugGatewayCommandTest.php
+++ b/Tests/Functional/Command/DebugGatewayCommandTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Payum\Bundle\PayumBundle\Tests\Functional\Command;
 
+use Payum\Bundle\PayumBundle\PayumVersion;
 use Payum\Bundle\PayumBundle\Command\DebugGatewayCommand;
 use Payum\Bundle\PayumBundle\Tests\Functional\WebTestCase;
 use Payum\Core\Registry\RegistryInterface;
@@ -45,7 +46,11 @@ class DebugGatewayCommandTest extends WebTestCase
 
         $output = $this->executeConsole(new DebugGatewayCommand($payum));
 
-        $this->assertStringContainsString('Found 2 gateways', $output);
+        // config_payum_v2.yml adds a third gateway built through the container
+        $this->assertStringContainsString(
+            PayumVersion::supportsDependencyInjection() ? 'Found 3 gateways' : 'Found 2 gateways',
+            $output
+        );
         $this->assertStringContainsString('fooGateway (Payum\Core\Gateway):', $output);
         $this->assertStringContainsString('barGateway (Payum\Core\Gateway):', $output);
     }

--- a/Tests/Functional/DependencyInjection/PayumExtensionTest.php
+++ b/Tests/Functional/DependencyInjection/PayumExtensionTest.php
@@ -146,10 +146,12 @@ class PayumExtensionTest extends TestCase
 
         $calls = $builder->getMethodCalls();
 
-        $this->assertEquals('addCoreGatewayFactoryConfig', $calls[6][0]);
+        $this->assertNotEmpty(array_filter($calls, static fn (array $call): bool => 'addCoreGatewayFactoryConfig' === $call[0]));
 
-        $this->assertEquals('setGatewayConfigStorage', $calls[7][0]);
-        $this->assertEquals('payum.dynamic_gateways.config_storage', (string) $calls[7][1][0]);
+        $setConfigStorage = array_values(array_filter($calls, static fn (array $call): bool => 'setGatewayConfigStorage' === $call[0]));
+
+        $this->assertCount(1, $setConfigStorage);
+        $this->assertEquals('payum.dynamic_gateways.config_storage', (string) $setConfigStorage[0][1][0]);
     }
 
     /**

--- a/Tests/Functional/Fixture/ExchangeRates.php
+++ b/Tests/Functional/Fixture/ExchangeRates.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Bundle\PayumBundle\Tests\Functional\Fixture;
+
+class ExchangeRates
+{
+}

--- a/Tests/Functional/Fixture/TaggedCaptureAction.php
+++ b/Tests/Functional/Fixture/TaggedCaptureAction.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Bundle\PayumBundle\Tests\Functional\Fixture;
+
+use Payum\Core\Action\ActionInterface;
+
+class TaggedCaptureAction implements ActionInterface
+{
+    public function execute($request): void
+    {
+    }
+
+    public function supports($request): bool
+    {
+        return false;
+    }
+}

--- a/Tests/Functional/PayumBuilderTest.php
+++ b/Tests/Functional/PayumBuilderTest.php
@@ -2,9 +2,11 @@
 namespace Payum\Bundle\PayumBundle\Tests\Functional;
 
 use Payum\Bundle\PayumBundle\Builder\CoreGatewayFactoryBuilder;
+use Payum\Bundle\PayumBundle\Builder\PayumCoreGatewayFactoryBuilder;
 use Payum\Bundle\PayumBundle\Builder\HttpRequestVerifierBuilder;
 use Payum\Bundle\PayumBundle\Builder\TokenFactoryBuilder;
 use Payum\Bundle\PayumBundle\ContainerAwareRegistry;
+use Payum\Bundle\PayumBundle\PayumVersion;
 use Payum\Core\PayumBuilder;
 
 class PayumBuilderTest extends WebTestCase
@@ -26,7 +28,11 @@ class PayumBuilderTest extends WebTestCase
         $reflectedConstraint = (new \ReflectionObject($builder))->getProperty('coreGatewayFactory');
         $reflectedConstraint->setAccessible(true);
         $constraint = $reflectedConstraint->getValue($builder);
-        $this->assertInstanceOf(CoreGatewayFactoryBuilder::class, $constraint);
+
+        $this->assertInstanceOf(
+            PayumVersion::supportsDependencyInjection() ? PayumCoreGatewayFactoryBuilder::class : CoreGatewayFactoryBuilder::class,
+            $constraint
+        );
     }
 
     public function testShouldContainHttpRequestVerifierBuilder(): void

--- a/Tests/Functional/PayumTest.php
+++ b/Tests/Functional/PayumTest.php
@@ -5,6 +5,7 @@ use Payum\Bundle\PayumBundle\Security\HttpRequestVerifier;
 use Payum\Bundle\PayumBundle\Security\TokenFactory;
 use Payum\Core\GatewayInterface;
 use Payum\Core\Model\ArrayObject;
+use Payum\Bundle\PayumBundle\PayumVersion;
 use Payum\Core\Payum;
 use Payum\Core\Security\GenericTokenFactory;
 use Payum\Core\Storage\StorageInterface;
@@ -69,7 +70,8 @@ class PayumTest extends WebTestCase
 
         $gateways = $payum->getGateways();
         $this->assertIsArray($gateways);
-        $this->assertCount(2, $gateways);
+        // config_payum_v2.yml adds a third gateway built through the container
+        $this->assertCount(PayumVersion::supportsDependencyInjection() ? 3 : 2, $gateways);
     }
 
     public function testShouldReturnGatewaysFactories(): void

--- a/Tests/Functional/PayumV2Test.php
+++ b/Tests/Functional/PayumV2Test.php
@@ -36,7 +36,7 @@ class PayumV2Test extends WebTestCase
     {
         $actions = $this->actionsOf($this->getPayum()->getGateway('diGateway'));
 
-        $this->assertContains(ObtainCreditCardAction::class, array_map(get_class(...), $actions));
+        $this->assertContains(ObtainCreditCardAction::class, array_map('get_class', $actions));
     }
 
     public function testShouldRegisterTheHttpRequestActionOfTheBundleOnIt(): void
@@ -45,7 +45,7 @@ class PayumV2Test extends WebTestCase
 
         $this->assertContains(
             \Payum\Bundle\PayumBundle\Action\GetHttpRequestAction::class,
-            array_map(get_class(...), $actions)
+            array_map('get_class', $actions)
         );
     }
 
@@ -53,14 +53,14 @@ class PayumV2Test extends WebTestCase
     {
         $actions = $this->actionsOf($this->getPayum()->getGateway('diGateway'));
 
-        $this->assertContains(TaggedCaptureAction::class, array_map(get_class(...), $actions));
+        $this->assertContains(TaggedCaptureAction::class, array_map('get_class', $actions));
     }
 
     public function testShouldNotRegisterAServiceTaggedForTheGatewayOnAnotherOne(): void
     {
         $actions = $this->actionsOf($this->getPayum()->getGateway('fooGateway'));
 
-        $this->assertNotContains(TaggedCaptureAction::class, array_map(get_class(...), $actions));
+        $this->assertNotContains(TaggedCaptureAction::class, array_map('get_class', $actions));
     }
 
     public function testShouldShareTheTaggedServicesOfTheApplicationWithPayum(): void

--- a/Tests/Functional/PayumV2Test.php
+++ b/Tests/Functional/PayumV2Test.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Bundle\PayumBundle\Tests\Functional;
+
+use Payum\Bundle\PayumBundle\Action\ObtainCreditCardAction;
+use Payum\Bundle\PayumBundle\PayumVersion;
+use Payum\Bundle\PayumBundle\Tests\Functional\Fixture\ExchangeRates;
+use Payum\Bundle\PayumBundle\Tests\Functional\Fixture\TaggedCaptureAction;
+use Payum\Core\Gateway;
+use Payum\Core\Payum;
+use ReflectionObject;
+
+/**
+ * What the bundle adds on top of payum/core 2.0: a gateway built through the container, with the
+ * actions of the bundle and the services the application tagged for it.
+ */
+class PayumV2Test extends WebTestCase
+{
+    protected function setUp(): void
+    {
+        if (! PayumVersion::supportsDependencyInjection()) {
+            $this->markTestSkipped('Needs payum/core 2.0 or later.');
+        }
+
+        parent::setUp();
+    }
+
+    public function testShouldBuildAGatewayOfTheCoreFactory(): void
+    {
+        $this->assertInstanceOf(Gateway::class, $this->getPayum()->getGateway('diGateway'));
+    }
+
+    public function testShouldRegisterTheActionsOfTheBundleOnIt(): void
+    {
+        $actions = $this->actionsOf($this->getPayum()->getGateway('diGateway'));
+
+        $this->assertContains(ObtainCreditCardAction::class, array_map(get_class(...), $actions));
+    }
+
+    public function testShouldRegisterTheHttpRequestActionOfTheBundleOnIt(): void
+    {
+        $actions = $this->actionsOf($this->getPayum()->getGateway('diGateway'));
+
+        $this->assertContains(
+            \Payum\Bundle\PayumBundle\Action\GetHttpRequestAction::class,
+            array_map(get_class(...), $actions)
+        );
+    }
+
+    public function testShouldRegisterAServiceTaggedForTheGatewayOnIt(): void
+    {
+        $actions = $this->actionsOf($this->getPayum()->getGateway('diGateway'));
+
+        $this->assertContains(TaggedCaptureAction::class, array_map(get_class(...), $actions));
+    }
+
+    public function testShouldNotRegisterAServiceTaggedForTheGatewayOnAnotherOne(): void
+    {
+        $actions = $this->actionsOf($this->getPayum()->getGateway('fooGateway'));
+
+        $this->assertNotContains(TaggedCaptureAction::class, array_map(get_class(...), $actions));
+    }
+
+    public function testShouldShareTheTaggedServicesOfTheApplicationWithPayum(): void
+    {
+        $container = static::getContainer()->get('payum.di.global_container');
+
+        $this->assertTrue($container->has(ExchangeRates::class));
+        $this->assertInstanceOf(ExchangeRates::class, $container->get(ExchangeRates::class));
+        $this->assertContains(ExchangeRates::class, $container->getKnownEntryNames());
+    }
+
+    public function testShouldStillBuildTheGatewaysOfTheOtherFactories(): void
+    {
+        $payum = $this->getPayum();
+
+        $this->assertInstanceOf(Gateway::class, $payum->getGateway('fooGateway'));
+        $this->assertInstanceOf(Gateway::class, $payum->getGateway('barGateway'));
+    }
+
+    private function getPayum(): Payum
+    {
+        return static::getContainer()->get('payum');
+    }
+
+    /**
+     * @return list<object>
+     */
+    private function actionsOf(Gateway $gateway): array
+    {
+        $reflected = (new ReflectionObject($gateway))->getProperty('actions');
+        $reflected->setAccessible(true);
+
+        return array_values($reflected->getValue($gateway));
+    }
+}

--- a/Tests/Functional/app/AppKernelShared.php
+++ b/Tests/Functional/app/AppKernelShared.php
@@ -51,5 +51,9 @@ class AppKernelShared extends Kernel
         $loader->load(__DIR__ . '/config/config.yml');
 
         $loader->load(__DIR__ . '/config/config_sf' . Kernel::MAJOR_VERSION . '.yml');
+
+        if (Payum\Bundle\PayumBundle\PayumVersion::supportsDependencyInjection()) {
+            $loader->load(__DIR__ . '/config/config_payum_v2.yml');
+        }
     }
 }

--- a/Tests/Functional/app/config/config_payum_v2.yml
+++ b/Tests/Functional/app/config/config_payum_v2.yml
@@ -1,0 +1,13 @@
+services:
+    Payum\Bundle\PayumBundle\Tests\Functional\Fixture\ExchangeRates:
+        tags:
+            - { name: payum.global_service }
+
+    Payum\Bundle\PayumBundle\Tests\Functional\Fixture\TaggedCaptureAction:
+        tags:
+            - { name: payum.action, gateway: diGateway }
+
+payum:
+    gateways:
+        diGateway:
+            factory: 'core'

--- a/Tests/PayumCoreGatewayFactoryTest.php
+++ b/Tests/PayumCoreGatewayFactoryTest.php
@@ -13,6 +13,7 @@ use Payum\Bundle\PayumBundle\PayumVersion;
 use Payum\Core\Action\ActionInterface;
 use Payum\Core\Bridge\PlainPhp\Action\GetHttpRequestAction;
 use Payum\Core\DI\ContainerConfiguration;
+use Payum\Core\DI\ListableContainerInterface;
 use Payum\Core\Extension\ExtensionInterface;
 use Payum\Core\Extension\Context;
 use Payum\Core\Gateway;
@@ -172,6 +173,10 @@ class PayumCoreGatewayFactoryTest extends TestCase
      */
     public function testShouldInjectAServiceOfTheApplicationIntoAnAction(): void
     {
+        if (! interface_exists(ListableContainerInterface::class)) {
+            $this->markTestSkipped('The installed payum/core cannot be told a container lists its entries.');
+        }
+
         $exchangeRates = new ExchangeRates();
         $formFactory = $this->createMock(FormFactoryInterface::class);
 

--- a/Tests/PayumCoreGatewayFactoryTest.php
+++ b/Tests/PayumCoreGatewayFactoryTest.php
@@ -56,7 +56,7 @@ class PayumCoreGatewayFactoryTest extends TestCase
         $this->assertContains($symfonyAction, $this->actionsOf($gateway));
         $this->assertNotContains(
             GetHttpRequestAction::class,
-            array_map(get_class(...), $this->actionsOf($gateway))
+            array_map('get_class', $this->actionsOf($gateway))
         );
     }
 
@@ -66,7 +66,7 @@ class PayumCoreGatewayFactoryTest extends TestCase
 
         $this->assertContains(
             ObtainCreditCardAction::class,
-            array_map(get_class(...), $this->actionsOf($gateway))
+            array_map('get_class', $this->actionsOf($gateway))
         );
     }
 

--- a/Tests/PayumCoreGatewayFactoryTest.php
+++ b/Tests/PayumCoreGatewayFactoryTest.php
@@ -1,0 +1,307 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Bundle\PayumBundle\Tests;
+
+use DI\ContainerBuilder;
+use Payum\Bundle\PayumBundle\Action\GetHttpRequestAction as SymfonyGetHttpRequestAction;
+use Payum\Bundle\PayumBundle\Action\ObtainCreditCardAction;
+use Payum\Bundle\PayumBundle\DI\SymfonyContainerAdapter;
+use Payum\Bundle\PayumBundle\PayumCoreGatewayFactory;
+use Payum\Bundle\PayumBundle\PayumVersion;
+use Payum\Core\Action\ActionInterface;
+use Payum\Core\Bridge\PlainPhp\Action\GetHttpRequestAction;
+use Payum\Core\DI\ContainerConfiguration;
+use Payum\Core\Extension\ExtensionInterface;
+use Payum\Core\Extension\Context;
+use Payum\Core\Gateway;
+use Payum\Core\PayumBuilder;
+use Payum\Core\Security\TokenFactoryInterface;
+use Payum\Core\Storage\FilesystemStorage;
+use Payum\Core\Model\Token;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use ReflectionClass;
+use ReflectionObject;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class PayumCoreGatewayFactoryTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (! PayumVersion::supportsDependencyInjection()) {
+            $this->markTestSkipped('PayumCoreGatewayFactory needs payum/core 2.0 or later.');
+        }
+    }
+
+    public function testShouldImplementContainerConfiguration(): void
+    {
+        $rc = new ReflectionClass(PayumCoreGatewayFactory::class);
+
+        $this->assertTrue($rc->implementsInterface(ContainerConfiguration::class));
+    }
+
+    public function testShouldUseTheHttpRequestActionOfTheBundle(): void
+    {
+        $symfonyAction = new SymfonyGetHttpRequestAction();
+
+        $gateway = $this->createGateway([
+            'payum.action.get_http_request' => $symfonyAction,
+        ]);
+
+        $this->assertContains($symfonyAction, $this->actionsOf($gateway));
+        $this->assertNotContains(
+            GetHttpRequestAction::class,
+            array_map(get_class(...), $this->actionsOf($gateway))
+        );
+    }
+
+    public function testShouldRegisterTheObtainCreditCardActionOfTheBundle(): void
+    {
+        $gateway = $this->createGateway();
+
+        $this->assertContains(
+            ObtainCreditCardAction::class,
+            array_map(get_class(...), $this->actionsOf($gateway))
+        );
+    }
+
+    public function testShouldAddTheActionsTaggedForAGateway(): void
+    {
+        $action = new TaggedAction();
+
+        $gateway = $this->createGateway([
+            PayumCoreGatewayFactory::ACTIONS => [
+                [
+                    'service' => $action,
+                    'prepend' => false,
+                ],
+            ],
+        ]);
+
+        $this->assertContains($action, $this->actionsOf($gateway));
+    }
+
+    public function testShouldAddTheActionsSharedByEveryGateway(): void
+    {
+        $action = new TaggedAction();
+
+        $gateway = $this->createGateway([
+            PayumCoreGatewayFactory::SHARED_ACTIONS => [
+                [
+                    'service' => $action,
+                    'prepend' => false,
+                ],
+            ],
+        ]);
+
+        $this->assertContains($action, $this->actionsOf($gateway));
+    }
+
+    public function testShouldPrependAnActionWhichAsksForIt(): void
+    {
+        $action = new TaggedAction();
+
+        $gateway = $this->createGateway([
+            PayumCoreGatewayFactory::ACTIONS => [
+                [
+                    'service' => $action,
+                    'prepend' => true,
+                ],
+            ],
+        ]);
+
+        $this->assertSame($action, $this->actionsOf($gateway)[0]);
+    }
+
+    public function testShouldAddTheExtensionsTaggedForAGateway(): void
+    {
+        $extension = new TaggedExtension();
+
+        $gateway = $this->createGateway([
+            PayumCoreGatewayFactory::EXTENSIONS => [
+                [
+                    'service' => $extension,
+                    'prepend' => false,
+                ],
+            ],
+        ]);
+
+        $this->assertContains($extension, $this->extensionsOf($gateway));
+    }
+
+    public function testShouldAddTheApisTaggedForAGateway(): void
+    {
+        $api = new \stdClass();
+
+        $gateway = $this->createGateway([
+            PayumCoreGatewayFactory::APIS => [
+                [
+                    'service' => $api,
+                    'prepend' => false,
+                ],
+            ],
+        ]);
+
+        $reflected = (new ReflectionObject($gateway))->getProperty('apis');
+        $reflected->setAccessible(true);
+
+        $this->assertContains($api, $reflected->getValue($gateway));
+    }
+
+    public function testShouldIgnoreAnEntryWithoutAService(): void
+    {
+        $gateway = $this->createGateway([
+            PayumCoreGatewayFactory::ACTIONS => [
+                ['prepend' => false],
+                [
+                    'service' => 'not an object',
+                ],
+            ],
+        ]);
+
+        $this->assertInstanceOf(Gateway::class, $gateway);
+    }
+
+    /**
+     * The reason the bundle hands Payum a global container: a service of the application can be
+     * injected into the constructor of an action of a gateway.
+     */
+    public function testShouldInjectAServiceOfTheApplicationIntoAnAction(): void
+    {
+        $exchangeRates = new ExchangeRates();
+        $formFactory = $this->createMock(FormFactoryInterface::class);
+
+        $payum = (new PayumBuilder())
+            ->setTokenStorage(new FilesystemStorage(sys_get_temp_dir(), Token::class, 'hash'))
+            ->setTokenFactory($this->createMock(TokenFactoryInterface::class))
+            ->setGlobalContainer(new SymfonyContainerAdapter(new ServiceLocator([
+                ExchangeRates::class => static fn (): ExchangeRates => $exchangeRates,
+            ])))
+            ->setCoreGatewayFactory(static fn (array $config): PayumCoreGatewayFactory => new AutowiringGatewayFactory(
+                array_replace($config, [
+                    FormFactoryInterface::class => $formFactory,
+                    RequestStack::class => new RequestStack(),
+                ])
+            ))
+            ->addGateway('aGateway', [
+                'factory' => 'core',
+            ])
+            ->getPayum()
+        ;
+
+        $autowired = null;
+        foreach ($this->actionsOf($payum->getGateway('aGateway')) as $action) {
+            if ($action instanceof AutowiredAction) {
+                $autowired = $action;
+            }
+        }
+
+        $this->assertInstanceOf(AutowiredAction::class, $autowired);
+        $this->assertSame($exchangeRates, $autowired->exchangeRates);
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    private function createGateway(array $config = []): Gateway
+    {
+        $factory = new PayumCoreGatewayFactory(array_replace([
+            FormFactoryInterface::class => $this->createMock(FormFactoryInterface::class),
+            RequestStack::class => new RequestStack(),
+        ], $config));
+
+        $containerBuilder = new ContainerBuilder();
+        $containerBuilder->addDefinitions($factory->configureContainer());
+
+        return $factory->createGateway($containerBuilder->build());
+    }
+
+    /**
+     * @return list<ActionInterface>
+     */
+    private function actionsOf(Gateway $gateway): array
+    {
+        $reflected = (new ReflectionObject($gateway))->getProperty('actions');
+        $reflected->setAccessible(true);
+
+        return array_values($reflected->getValue($gateway));
+    }
+
+    /**
+     * @return list<ExtensionInterface>
+     */
+    private function extensionsOf(Gateway $gateway): array
+    {
+        $reflected = (new ReflectionObject($gateway))->getProperty('extensions');
+        $reflected->setAccessible(true);
+
+        $collection = $reflected->getValue($gateway);
+
+        $reflected = (new ReflectionObject($collection))->getProperty('extensions');
+        $reflected->setAccessible(true);
+
+        return array_values($reflected->getValue($collection));
+    }
+}
+
+class TaggedAction implements ActionInterface
+{
+    public function execute($request): void
+    {
+    }
+
+    public function supports($request): bool
+    {
+        return false;
+    }
+}
+
+class TaggedExtension implements ExtensionInterface
+{
+    public function onPreExecute(Context $context): void
+    {
+    }
+
+    public function onExecute(Context $context): void
+    {
+    }
+
+    public function onPostExecute(Context $context): void
+    {
+    }
+}
+
+class ExchangeRates
+{
+}
+
+class AutowiredAction implements ActionInterface
+{
+    public function __construct(
+        public ExchangeRates $exchangeRates
+    ) {
+    }
+
+    public function execute($request): void
+    {
+    }
+
+    public function supports($request): bool
+    {
+        return false;
+    }
+}
+
+class AutowiringGatewayFactory extends PayumCoreGatewayFactory
+{
+    public function getActions(): array
+    {
+        return array_merge(parent::getActions(), [
+            AutowiredAction::class,
+        ]);
+    }
+}

--- a/Tests/PayumVersionTest.php
+++ b/Tests/PayumVersionTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Bundle\PayumBundle\Tests;
+
+use Payum\Bundle\PayumBundle\PayumVersion;
+use Payum\Core\DI\ContainerConfiguration;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+class PayumVersionTest extends TestCase
+{
+    public function testShouldBeFinal(): void
+    {
+        $rc = new ReflectionClass(PayumVersion::class);
+
+        $this->assertTrue($rc->isFinal());
+    }
+
+    public function testShouldTellWhetherPayumBuildsItsGatewaysWithAContainer(): void
+    {
+        $this->assertSame(
+            interface_exists(ContainerConfiguration::class),
+            PayumVersion::supportsDependencyInjection()
+        );
+    }
+
+    public function testShouldGiveTheSameAnswerEveryTime(): void
+    {
+        $this->assertSame(
+            PayumVersion::supportsDependencyInjection(),
+            PayumVersion::supportsDependencyInjection()
+        );
+    }
+}

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,43 @@
 
 Library [upgrades](https://github.com/Payum/Payum/blob/master/UPGRADE.md).
 
+## Payum 2.0
+
+The bundle works with both payum/core 1.x and payum/core 2.0. Which one is installed is detected at
+compile time, and the services which differ between the two are loaded from
+`Resources/config/payum_v1.php` or `Resources/config/payum_v2.php` accordingly. Nothing has to be
+changed in an application to keep running on 1.x.
+
+What changes when payum/core 2.0 is installed:
+
+* Payum builds every gateway with a dependency injection container. The bundle hands it the services of
+  the application as its global container (`payum.di.global_container`), so that a gateway can resolve
+  them and, when payum/core is able to be told a container lists its entries, inject them into the
+  constructor of an action.
+* Any service tagged `payum.global_service` is shared with Payum this way. The tag takes an optional
+  `id` attribute for the name Payum should know it under, which is how a service is shared under the
+  interface an action type-hints:
+
+  ```yaml
+  services:
+      App\Payment\ExchangeRates:
+          tags:
+              - { name: payum.global_service, id: App\Payment\ExchangeRatesInterface }
+  ```
+
+* The `payum.action`, `payum.api` and `payum.extension` tags keep working and keep the same attributes.
+  A tagged service now reaches a gateway as an entry of its container rather than as an `"@id"` string
+  resolved at runtime, which means the `alias` attribute no longer names anything and is ignored.
+* `Payum\Bundle\PayumBundle\ContainerAwareCoreGatewayFactory` and
+  `Payum\Bundle\PayumBundle\Builder\CoreGatewayFactoryBuilder` are only used with payum/core 1.x.
+  `Payum\Bundle\PayumBundle\PayumCoreGatewayFactory` takes their place, built by
+  `Payum\Bundle\PayumBundle\Builder\PayumCoreGatewayFactoryBuilder`. Replacing
+  `payum.core_gateway_factory_builder` with a factory of your own still works, it now has to build a
+  factory implementing `Payum\Core\DI\ContainerConfiguration`.
+* A gateway factory which does not implement `Payum\Core\DI\ContainerConfiguration` - which is still
+  every gateway factory payum/core ships - is built the way it was in 1.x, and payum/core triggers a
+  deprecation for it.
+
 ## 2.0 to 2.1
 
 * `payum.http_client` service was removed. Use gateway's config to overwrite it.

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "payum/core": "^1.7.2",
+        "payum/core": "^1.7.2 || ^2.0",
         "symfony/framework-bundle": "^5.4 || ^6.0 || ^7.0 || ^8.0",
         "symfony/form": "^5.4 || ^6.0 || ^7.0 || ^8.0",
         "symfony/validator": "^5.4 || ^6.0 || ^7.0 || ^8.0",


### PR DESCRIPTION
## Summary

Makes the bundle work against both `payum/core` 1.x and 2.0. Which one is installed is detected at compile time and the services which differ are loaded accordingly, so nothing has to change in an application to keep running on 1.x.

The interesting difference in 2.0 is that Payum builds every gateway with a dependency injection container. The bundle hands it the application's services as the global container, which is what lets a service of the application be injected into the constructor of an action.

## How the version is detected

`PayumVersion::supportsDependencyInjection()` asks `interface_exists(ContainerConfiguration::class)` rather than reading Composer's metadata. `payum/payum` replaces `payum/core`, and neither declares a version outside of a release, so a development install reports a version that says nothing about which APIs are present. The DI interfaces added in 2.0 do.

## Changes

- **Service config split** — the services which differ between generations move to `Resources/config/payum_v1.php` and `payum_v2.php`; `PayumExtension` loads one or the other.
- **`PayumCoreGatewayFactory`** — implements `Payum\Core\DI\ContainerConfiguration` and takes the place of `ContainerAwareCoreGatewayFactory` / `CoreGatewayFactoryBuilder` on 2.0. Replacing `payum.core_gateway_factory_builder` with your own still works; it now has to build a factory implementing `ContainerConfiguration`.
- **New `payum.global_service` tag** — shares an application service with Payum. The optional `id` attribute names it, which is how a service is shared under the interface an action type-hints:

  ```yaml
  services:
      App\Payment\ExchangeRates:
          tags:
              - { name: payum.global_service, id: App\Payment\ExchangeRatesInterface }
  ```

- **Existing tags keep working** — `payum.action`, `payum.api` and `payum.extension` keep the same attributes. A tagged service now reaches a gateway as an entry of its container rather than as an `"@id"` string resolved at runtime, so the `alias` attribute no longer names anything and is ignored.
- **Gateway factories that predate `ContainerConfiguration`** — still every factory `payum/core` ships — are built the way they were in 1.x, and `payum/core` triggers a deprecation for them.
- **`composer.json`** — `payum/core` widened to `^1.7.2 || ^2.0`.
- **`UPGRADE.md`** — documents all of the above under a "Payum 2.0" heading.

## Tests

New coverage in `PayumCoreGatewayFactoryTest`, `PayumVersionTest`, `Tests/DI/SymfonyContainerAdapterTest`, `BuildGlobalContainerPassTest`, and a functional `PayumV2Test` booting the kernel with `config_payum_v2.yml`.

The CI matrix gains `payum: 2.x` legs which swap the sub-package dev requirements for `payum/payum:2.x-dev` — the gateways became part of the monorepo in 2.0, so they cannot be installed alongside it.

## Note on the second commit

`14b4233` skips the autowiring test when the installed `payum/core` cannot be told a container lists its entries. That was needed while `ListableContainerInterface` was still unmerged; it landed in Payum/Payum#1046, so on `2.x-dev` the guard no longer trips and the test asserts for real. The skip stays for anyone running the suite against a `payum/core` without it.

Running the suite locally against `payum/core` 1.x skips the 2.0-specific tests as designed — the `payum: 2.x` CI legs are what exercise the new paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ARB2EkkjTiRA2WvJjgwteU

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARB2EkkjTiRA2WvJjgwteU)_